### PR TITLE
Unix Domain Socket Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -8,37 +9,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+Implement Unix domain socket support.
+
 ## [0.1.6] - 2020-09-14
+
 ### Changed
+
 - Changed `Client::get` to return `Option<Value>` in the non-error case to indicate hit vs miss.
 - Fixed a bug where reads in a particular situation would stall if the client attempted a follow-up
   read after getting an "incomplete" protocol parse result during the last loop iteration.
 
 ### Added
+
 - Added `Client::stats` to get a list of statistics from the server.
 
 ## [0.1.5] - 2020-09-13
+
 ### Changed
+
 - Make `ttl` optional on `Client::set`.
 - Expose metadump "BUSY" and "BADCLASS" responses via `Error`.
 - Break out `ErrorKind::Generic` as `ErrorKind::NonexistentCommand` to allow for actual generic
   errors while properly capturing `ERROR\r\n` responses from memcached.
 
 ### Added
+
 - A ton of documentation on public types.
 
 ## [0.1.4] - 2020-09-12
+
 ### Added
+
 - Added support for dumping keys via the LRU crawler interface.
 
 ## [0.1.2] - 2020-07-13
+
 ### Changed
+
 - Bug fixes / parsing changes.
 
 ## [0.1.1] - 2020-07-13
+
 ### Changed
+
 - Bug fixes / parsing changes.
 
 ## [0.1.0] - 2020-07-13
+
 ### Added
+
 - Initial commit.  Basic get/set support.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ pin-project = "1.0"
 futures = "0.3"
 tokio = { version = "1.26", default-features = false, features = ["io-util"] }
 async-stream = "0.3"
+url = "2.5.2"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ udp = []
 
 [[example]]
 name = "basic"
-path = "examples/basic.rs"
+path = "examples/tcp.rs"

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # async-memcache
+
 async-memcache is an async [memcached](https://memcached.org/) client implementation for Tokio.
 
 *Warning*: This is a work in progress crate.
 
 ## Features
+
 This crate only targets the ASCII protocol, as the binary protocol has been deprecated and is no
 longer actively being improved.
 
 - [x] TCP connection
 - [ ] UDP connection
-- [ ] UNIX domain socket connection
+- [x] UNIX domain socket connection
 - [ ] Authentication
 - [ ] TLS
 
 ## License
+
 MIT

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -2,7 +2,7 @@ use async_memcached::Client;
 
 #[tokio::main]
 async fn main() {
-    let mut client = Client::new("tcp://localhost:11211")
+    let mut client = Client::new("localhost:11211")
         .await
         .expect("failed to create client");
 

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -2,7 +2,7 @@ use async_memcached::Client;
 
 #[tokio::main]
 async fn main() {
-    let mut client = Client::new("localhost:11211")
+    let mut client = Client::new("tcp://localhost:11211")
         .await
         .expect("failed to create client");
 

--- a/examples/unix.rs
+++ b/examples/unix.rs
@@ -1,0 +1,18 @@
+use async_memcached::Client;
+
+#[tokio::main]
+async fn main() {
+    let mut client = Client::new("unix:///tmp/memcached.sock")
+        .await
+        .expect("failed to create client");
+
+    match client.set("foo", "might do popeyes", Some(5), None).await {
+        Ok(()) => println!("set 'foo' successfully"),
+        Err(status) => println!("got status during 'foo' set: {:?}", status),
+    }
+
+    match client.get("foo").await {
+        Ok(value) => println!("got value for 'foo': {:?}", value),
+        Err(status) => println!("got status during 'foo' get: {:?}", status),
+    }
+}

--- a/release.toml
+++ b/release.toml
@@ -2,7 +2,7 @@ no-dev-version = true
 sign-commit = true
 sign-tag = true
 pre-release-replacements = [
-  {file="CHANGELOG.md", search="Unreleased", replace="{{version}}"},
-  {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
-  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate"},
+  { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+  { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate" },
 ]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -74,8 +74,10 @@ impl Connection {
             ))
         })?;
 
+        println!("Connecting to {:?}", dsn);
+
         match dsn.scheme() {
-            "tcp" => TcpStream::connect(&*dsn.socket_addrs(|| None)?)
+            "tcp" | "" => TcpStream::connect(&*dsn.socket_addrs(|| None)?)
                 .await
                 .map(|c| Connection::Tcp(BufReader::new(BufWriter::new(c))))
                 .map_err(Error::Io),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -3,13 +3,14 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, BufReader, BufWriter};
-use tokio::net::TcpStream;
+use tokio::net::{TcpStream, UnixStream};
 
 use crate::Error;
 
 #[pin_project(project = ConnectionProjection)]
 pub enum Connection {
     Tcp(#[pin] BufReader<BufWriter<TcpStream>>),
+    Unix(#[pin] BufReader<BufWriter<UnixStream>>),
 }
 
 impl AsyncRead for Connection {
@@ -20,6 +21,7 @@ impl AsyncRead for Connection {
     ) -> Poll<io::Result<()>> {
         match self.project() {
             ConnectionProjection::Tcp(s) => s.poll_read(cx, buf),
+            ConnectionProjection::Unix(s) => s.poll_read(cx, buf),
         }
     }
 }
@@ -28,18 +30,21 @@ impl AsyncWrite for Connection {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
         match self.project() {
             ConnectionProjection::Tcp(s) => s.poll_write(cx, buf),
+            ConnectionProjection::Unix(s) => s.poll_write(cx, buf),
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
         match self.project() {
             ConnectionProjection::Tcp(s) => s.poll_flush(cx),
+            ConnectionProjection::Unix(s) => s.poll_flush(cx),
         }
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
         match self.project() {
             ConnectionProjection::Tcp(s) => s.poll_shutdown(cx),
+            ConnectionProjection::Unix(s) => s.poll_shutdown(cx),
         }
     }
 }
@@ -48,21 +53,40 @@ impl AsyncBufRead for Connection {
     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<&[u8]>> {
         match self.project() {
             ConnectionProjection::Tcp(s) => s.poll_fill_buf(cx),
+            ConnectionProjection::Unix(s) => s.poll_fill_buf(cx),
         }
     }
 
     fn consume(self: Pin<&mut Self>, amt: usize) {
         match self.project() {
             ConnectionProjection::Tcp(s) => s.consume(amt),
+            ConnectionProjection::Unix(s) => s.consume(amt),
         }
     }
 }
 
 impl Connection {
     pub async fn new<S: AsRef<str>>(dsn: S) -> Result<Connection, Error> {
-        TcpStream::connect(dsn.as_ref())
-            .await
-            .map(|c| Connection::Tcp(BufReader::new(BufWriter::new(c))))
-            .map_err(Error::Io)
+        let dsn = url::Url::parse(dsn.as_ref()).map_err(|e| {
+            Error::Connect(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Failed to parse URL: {}", e),
+            ))
+        })?;
+
+        match dsn.scheme() {
+            "tcp" => TcpStream::connect(&*dsn.socket_addrs(|| None)?)
+                .await
+                .map(|c| Connection::Tcp(BufReader::new(BufWriter::new(c))))
+                .map_err(Error::Io),
+            "unix" => UnixStream::connect(dsn.path())
+                .await
+                .map(|c| Connection::Unix(BufReader::new(BufWriter::new(c))))
+                .map_err(Error::Io),
+            _ => Err(Error::Connect(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid scheme",
+            ))),
+        }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -123,24 +123,24 @@ mod tests {
     #[tokio::test]
     async fn test_unknown_scheme() {
         assert_eq!(
-            Addr::parse("localhost:11211").unwrap(),
-            Addr::Unknown("localhost:11211".to_string())
+            Addr::parse("localhost:11211"),
+            Ok(Addr::Unknown("localhost:11211".to_string()))
         )
     }
 
     #[tokio::test]
     async fn test_tcp_scheme() {
         assert_eq!(
-            Addr::parse("tcp://localhost:11211").unwrap(),
-            Addr::Tcp("localhost:11211".to_string())
+            Addr::parse("tcp://localhost:11211"),
+            Ok(Addr::Tcp("localhost:11211".to_string()))
         )
     }
 
     #[tokio::test]
     async fn test_unix_scheme() {
         assert_eq!(
-            Addr::parse("unix:///tmp/memcached.sock").unwrap(),
-            Addr::Unix("/tmp/memcached.sock".to_string())
+            Addr::parse("unix:///tmp/memcached.sock"),
+            Ok(Addr::Unix("/tmp/memcached.sock".to_string()))
         )
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,17 @@ pub enum Error {
     Protocol(Status),
 }
 
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Connect(e1), Self::Connect(e2)) => e1.kind() == e2.kind(),
+            (Self::Io(e1), Self::Io(e2)) => e1.kind() == e2.kind(),
+            (Self::Protocol(s1), Self::Protocol(s2)) => s1 == s2,
+            _ => false,
+        }
+    }
+}
+
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,8 @@ use std::{fmt, io};
 /// Error type for [`Client`](crate::Client) operations.
 #[derive(Debug)]
 pub enum Error {
-    /// Connection error.
+    /// Connect error.
+    /// Useful for distinguishing between transitive I/O errors and connection errors.
     Connect(io::Error),
     /// I/O-related error.
     Io(io::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,8 @@ use std::{fmt, io};
 /// Error type for [`Client`](crate::Client) operations.
 #[derive(Debug)]
 pub enum Error {
+    /// Connection error.
+    Connect(io::Error),
     /// I/O-related error.
     Io(io::Error),
     /// A protocol-level error i.e. a failed operation or message that
@@ -23,6 +25,7 @@ impl std::error::Error for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Self::Connect(e) => write!(f, "connect: {}", e),
             Self::Io(e) => write!(f, "io: {}", e),
             Self::Protocol(e) => write!(f, "protocol: {}", e),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ impl Client {
     /// Creates a new [`Client`] based on the given data source string.
     ///
     /// Supports UNIX domain sockets and TCP connections.
-    /// For TCP: the DSN should be in the format of `tcp://<ip>:<port>`.
+    /// For TCP: the DSN should be in the format of `tcp://<IP>:<port>` or `<IP>:<port>`.
     /// For UNIX: the DSN should be in the format of `unix://<path>`.
     pub async fn new<S: AsRef<str>>(dsn: S) -> Result<Client, Error> {
         let connection = Connection::new(dsn).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,7 +387,7 @@ mod tests {
     #[ignore = "Relies on a running memcached server"]
     #[tokio::test]
     async fn test_add() {
-        let mut client = Client::new("localhost:47386")
+        let mut client = Client::new("tcp://localhost:11211")
             .await
             .expect("Failed to connect to server");
 
@@ -402,7 +402,7 @@ mod tests {
     #[ignore = "Relies on a running memcached server"]
     #[tokio::test]
     async fn test_delete() {
-        let mut client = Client::new("localhost:47386")
+        let mut client = Client::new("tcp://localhost:11211")
             .await
             .expect("Failed to connect to server");
 


### PR DESCRIPTION
## Description

This PR adds support for connecting to Memcached via Unix domain sockets. We've found considerable performance gains with UDS: ~2x throughput and -20% p99 latency.

## 🎩 

```
❯ memcached -ds /tmp/memcached.sock && cargo run --package async-memcached --example unix
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/unix`
url path: /tmp/memcached.sock
set 'foo' successfully
got value for 'foo': Some(Value { key: [102, 111, 111], cas: None, flags: 0, data: [109, 105, 103, 104, 116, 32, 100, 111, 32, 112, 111, 112, 101, 121, 101, 115] })

❯ memcached -d && cargo run --package async-memcached --example tcp
got value for 'foo': None
set 'foo' successfully
set 'bar' successfully
got values: [Value { key: [102, 111, 111], cas: None, flags: 0, data: [109, 105, 103, 104, 116, 32, 100, 111, 32, 112, 111, 112, 101, 121, 101, 115] }, Value { key: [98, 97, 114], cas: None, flags: 0, data: [98, 97, 114, 118, 97, 108, 117, 101] }]
got 92 stat entries!
curr items: Some("2")
```
