### PR TITLE
Remove `dev-version` Release Flag

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,3 @@
-no-dev-version = true
 sign-commit = true
 sign-tag = true
 pre-release-replacements = [


### PR DESCRIPTION
## Description

`[no-dev-version` was removed in cargo-release v0.19.0 in favour of `dev-version`](https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md?plain=1#L376). Then, [`dev-version` was removed in v0.22.0](https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md?plain=1#L214).