### PR TITLE
Add homepage, repository, and documentation link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ readme = "README.md"
 license = "MIT"
 description = "An Tokio-based memcached client for Rust."
 keywords = ["memcached", "async"]
+homepage = "https://github.com/Shopify/async-memcached"
+documentation = "https://docs.rs/async-memcached"
+repository = "https://github.com/Shopify/async-memcached"
 
 [dependencies]
 bytes = "1.4"


### PR DESCRIPTION
## Description

This is necessary to publish a crate via `cargo release`.

```
error: async-memcached is missing the following fields:
  documentation || homepage || repository
```