### PR TITLE
Remove pre-release directives

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,2 @@
 sign-commit = true
 sign-tag = true
-pre-release-replacements = [
-  { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
-  { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
-  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate" },
-]


### PR DESCRIPTION
## Description

This is a relic from the previous maintainer and prevents us from PRing a version bump which gets merged to main and then `cargo publish` is ran.