### PR TITLE
Add Benchmark Suite & Disable Nagle's Algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ url = "2.5.2"
 lazy_static = "1.4"
 tokio = { version = "1.26", features = ["full"] }
 rand = "0.8"
+criterion = { version = "0.5.1", features = ["async_tokio"] }
 
 [features]
 default = []
@@ -36,3 +37,7 @@ udp = []
 [[example]]
 name = "basic"
 path = "examples/tcp.rs"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -77,7 +77,7 @@ fn bench_set_large(c: &mut Criterion) {
             let large_payload = "a".repeat(LARGE_PAYLOAD_SIZE);
             let start = std::time::Instant::now();
             for _ in 0..iters {
-                let _ = client.set("large_foo", &large_payload, Some(5), None).await;
+                let _ = client.set("large_foo", &large_payload, None, None).await;
             }
             start.elapsed()
         });
@@ -91,7 +91,7 @@ fn bench_get_large(c: &mut Criterion) {
     rt.block_on(async {
         let mut client = setup_client().await;
         client
-            .set("large_foo", &large_payload, Some(3600), None)
+            .set("large_foo", &large_payload, None, None)
             .await
             .unwrap();
     });
@@ -116,10 +116,7 @@ fn bench_get_many_large(c: &mut Criterion) {
     rt.block_on(async {
         let mut client = setup_client().await;
         for key in keys {
-            client
-                .set(key, &large_payload, Some(3600), None)
-                .await
-                .unwrap();
+            client.set(key, &large_payload, None, None).await.unwrap();
         }
     });
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,147 @@
+use async_memcached::Client;
+use criterion::{criterion_group, criterion_main, Criterion};
+use tokio::runtime::Runtime;
+
+const LARGE_PAYLOAD_SIZE: usize = 1024 * 1024; // Memcached's default maximum payload size
+
+async fn setup_client() -> Client {
+    Client::new("tcp://127.0.0.1:11211")
+        .await
+        .expect("failed to create client")
+}
+
+fn bench_get(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    rt.block_on(async {
+        let mut client = setup_client().await;
+        client.set("foo", "bar", None, None).await.unwrap();
+    });
+
+    c.bench_function("get_small", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut client = setup_client().await;
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client.get("foo").await;
+            }
+            start.elapsed()
+        });
+    });
+}
+
+fn bench_set(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    c.bench_function("set_small", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut client = setup_client().await;
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client.set("foo", "bar", None, None).await;
+            }
+            start.elapsed()
+        });
+    });
+}
+
+fn bench_get_many(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let keys = &["foo", "bar", "baz"];
+
+    rt.block_on(async {
+        let mut client = setup_client().await;
+        for key in keys {
+            client.set(key, "zzz", None, None).await.unwrap();
+        }
+    });
+
+    c.bench_function("get_many_small", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut client = setup_client().await;
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client.get_many(keys).await;
+            }
+            start.elapsed()
+        });
+    });
+}
+
+fn bench_set_large(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    c.bench_function("set_large", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut client = setup_client().await;
+            let large_payload = "a".repeat(LARGE_PAYLOAD_SIZE);
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client.set("large_foo", &large_payload, Some(5), None).await;
+            }
+            start.elapsed()
+        });
+    });
+}
+
+fn bench_get_large(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let large_payload = "a".repeat(LARGE_PAYLOAD_SIZE);
+
+    rt.block_on(async {
+        let mut client = setup_client().await;
+        client
+            .set("large_foo", &large_payload, Some(3600), None)
+            .await
+            .unwrap();
+    });
+
+    c.bench_function("get_large", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut client = setup_client().await;
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client.get("large_foo").await;
+            }
+            start.elapsed()
+        });
+    });
+}
+
+fn bench_get_many_large(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let large_payload = "a".repeat(LARGE_PAYLOAD_SIZE);
+    let keys = &["large_foo1", "large_foo2", "large_foo3"];
+
+    rt.block_on(async {
+        let mut client = setup_client().await;
+        for key in keys {
+            client
+                .set(key, &large_payload, Some(3600), None)
+                .await
+                .unwrap();
+        }
+    });
+
+    c.bench_function("get_many_large", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut client = setup_client().await;
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client.get_many(keys).await;
+            }
+            start.elapsed()
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_get,
+    bench_set,
+    bench_get_many,
+    bench_set_large,
+    bench_get_large,
+    bench_get_many_large
+);
+criterion_main!(benches);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,7 @@ use async_memcached::Client;
 use criterion::{criterion_group, criterion_main, Criterion};
 use tokio::runtime::Runtime;
 
-const LARGE_PAYLOAD_SIZE: usize = 1024 * 1024; // Memcached's default maximum payload size
+const LARGE_PAYLOAD_SIZE: usize = 1000 * 1024; // Memcached's ~default maximum payload size
 
 async fn setup_client() -> Client {
     Client::new("tcp://127.0.0.1:11211")

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -117,7 +117,7 @@ impl Connection {
                     ))
                 })?;
                 let socket = TcpSocket::new_v4().map_err(Error::Connect)?;
-                socket.nodelay().map_err(Error::Connect)?;
+                socket.set_nodelay(true).map_err(Error::Connect)?;
                 let stream = socket.connect(addr).await.map_err(Error::Connect)?;
                 Ok(Connection::Tcp(BufReader::new(BufWriter::new(stream))))
             }


### PR DESCRIPTION
## Description

There are two things going on in this PR:
1. Adding a very basic benchmarking suite
2. [Disabling Nagle's algorithm](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html#method.set_nodelay)

I was performing some benchmarks in our staging environment and noticed that the tail latencies of small payloads were extremely high (>15ms). After using this patch, it went back down to less than a couple hundred microseconds (as expected).

There isn't really a difference when I run these microbenchmarks locally:
```
     Running benches/bench.rs (target/release/deps/bench-9de9bcc0a2d0b870)
get_small               time:   [24.343 µs 24.514 µs 24.750 µs]
                        change: [-1.3206% -0.4650% +0.3909%] (p = 0.29 > 0.05)
                        No change in performance detected.
Found 18 outliers among 100 measurements (18.00%)
  4 (4.00%) low severe
  7 (7.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

set_small               time:   [24.989 µs 25.093 µs 25.192 µs]
                        change: [-1.0483% -0.0873% +0.8888%] (p = 0.87 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) low severe
  5 (5.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe

get_many_small          time:   [25.460 µs 25.571 µs 25.682 µs]
                        change: [-0.8016% +0.4063% +1.3491%] (p = 0.51 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

set_large               time:   [107.98 µs 112.53 µs 119.64 µs]
                        change: [+2.0319% +19.866% +51.729%] (p = 0.18 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe

get_large               time:   [121.02 µs 121.63 µs 122.35 µs]
                        change: [-5.7321% -2.1268% +0.8072%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe

get_many_large          time:   [395.47 µs 398.51 µs 402.08 µs]
                        change: [-12.236% -9.0026% -5.7699%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
```

### Additional Resources:
- https://rachelbythebay.com/w/2020/10/14/lag/
- https://brooker.co.za/blog/2024/05/09/nagle.html
- https://eklitzke.org/the-caveats-of-tcp-nodelay