### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.3.0] - 2024-08-30
+
 ### Added
 
 - Added arithmetic methods to the ASCII protocol:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Added arithmetic methods to the ASCII protocol:
+  - `increment`
+  - `increment_no_reply`
+  - `decrement`
+  - `decrement_no_reply`
+- Added benchmarking suite
+
+### Changed
+
+- Disabled Nagle's Algorithm
+- Improved README instructions and sample code for `tcp` and `uds` connections
+
 ## [0.2.0] - 2024-07-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-memcached"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
 readme = "README.md"

--- a/release.toml
+++ b/release.toml
@@ -1,2 +1,7 @@
 sign-commit = true
 sign-tag = true
+pre-release-replacements = [
+  { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+  { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate" },
+]


### PR DESCRIPTION
Diff from dryrun of `cargo release minor -v`:
```
   Upgrading async-memcached from 0.2.0 to 0.3.0
[2024-08-30T18:23:36Z DEBUG cargo_release::ops::cargo] change:
    --- /Users/mark/src/github.com/Shopify/async-memcached/Cargo.toml   original
    +++ /Users/mark/src/github.com/Shopify/async-memcached/Cargo.toml   updated
    @@ -1,6 +1,6 @@
     [package]
     name = "async-memcached"
    -version = "0.2.0"
    +version = "0.3.0"
     authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
     edition = "2018"
     readme = "README.md"
    
[2024-08-30T18:23:36Z DEBUG cargo_release::steps::release] updating lock file
[2024-08-30T18:23:36Z DEBUG cargo_release::ops::replace] processing replacements for file /Users/mark/src/github.com/Shopify/async-memcached/CHANGELOG.md
   Replacing in CHANGELOG.md
--- CHANGELOG.md        original
+++ CHANGELOG.md        replaced
@@ -9,6 +9,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+## [0.3.0] - 2024-08-30
+
 ### Added
 
 - Added arithmetic methods to the ASCII protocol:

  Publishing async-memcached
```