### PR TITLE
Fix value_serializer import so consumers can access the public trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use self::parser::{
 pub use self::parser::{ErrorKind, KeyMetadata, MetadumpResponse, StatsResponse, Status, Value};
 
 mod value_serializer;
-use self::value_serializer::AsMemcachedValue;
+pub use self::value_serializer::AsMemcachedValue;
 
 /// High-level memcached client.
 ///


### PR DESCRIPTION
Minor bugfix to allow consumers to access public implementation of `AsMemcachedValue` trait.