### PR TITLE
Deprecate `get_many` method name in favor of `get_multi` to conform with expected memcached API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed the function signature of `get_many`.  This method has been renamed to `get_multi` and now returns `Result<FxHashMap<Vec<u8>, Result<Option<Value>, Error>>, Error>` instead of `Result<Vec<Value>, Error>`.  The `get_many` alias, but it is now deprecated and will be removed in a future version.
+- Changed the name of `get_many`.  This method has been renamed to `get_multi`.  `get_many` will persist as an alias, but it is now deprecated and will be removed in a future version.
+- Instances of `std::collections::HashMap` have been changed to `fxhash::FxHashMap` to improve performance.
 - Outlined the process of releasing a new crate version in `README.md`.
 
 ## [0.3.1] - 2024-09-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Implemented `set_multi` method.
-- Added `flush_all` method to the ASCII protocol
-- Added `delete_multi_no_reply` method to the ASCII protocol
+- Added `set_multi` method to the ASCII protocol.
+- Added `flush_all` method to the ASCII protocol.
+- Added `delete_multi_no_reply` method to the ASCII protocol.
 
 ### Changed
 
-- Outlined the process of releasing a new crate version in README.md
+- Changed the function signature of `get_many`.  This method has been renamed to `get_multi` and now returns `Result<FxHashMap<Vec<u8>, Result<Option<Value>, Error>>, Error>` instead of `Result<Vec<Value>, Error>`.  The `get_many` alias, but it is now deprecated and will be removed in a future version.
+- Outlined the process of releasing a new crate version in `README.md`.
 
 ## [0.3.1] - 2024-09-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.26", default-features = false, features = ["io-util"] }
 async-stream = "0.3"
 url = "2.5.2"
 serial_test = "3.1.1"
+fxhash = "0.2.1"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -124,7 +124,7 @@ fn bench_get_many(c: &mut Criterion) {
             let mut client = setup_client().await;
             let start = std::time::Instant::now();
             for _ in 0..iters {
-                let _ = client.get_many(keys).await;
+                let _ = client.get_multi(keys).await;
             }
             start.elapsed()
         });
@@ -249,7 +249,7 @@ fn bench_get_many_large(c: &mut Criterion) {
             let mut client = setup_client().await;
             let start = std::time::Instant::now();
             for _ in 0..iters {
-                let _ = client.get_many(keys).await;
+                let _ = client.get_multi(keys).await;
             }
             start.elapsed()
         });

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -23,7 +23,7 @@ async fn main() {
 
     let keys = &["foo", "bar"];
 
-    match client.get_many(keys).await {
+    match client.get_multi(keys).await {
         Ok(values) => println!("got values: {:?}", values),
         Err(status) => println!("got status during get_many: {:?}", status),
     }

--- a/examples/unix.rs
+++ b/examples/unix.rs
@@ -22,7 +22,7 @@ async fn main() {
     }
 
     let keys = &["foo", "bar"];
-    match client.get_many(keys).await {
+    match client.get_multi(keys).await {
         Ok(values) => println!("got values: {:?}", values),
         Err(status) => println!("got status during get_many: {:?}", status),
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -229,7 +229,7 @@ async fn test_set_fails_with_value_too_large() {
 #[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
-async fn test_get_many() {
+async fn test_get_multi() {
     let keys = vec!["mg-key1", "mg-key2", "mg-key3"];
     let values = vec!["value1", "value2", "value3"];
 
@@ -254,7 +254,7 @@ async fn test_get_many() {
 #[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
-async fn test_get_many_with_nonexistent_key() {
+async fn test_get_multi_with_nonexistent_key() {
     let mut keys = vec!["mgne-key1", "mgne-key2", "mgne-key3"];
     let values = vec!["value1", "value2", "value3"];
 
@@ -272,26 +272,49 @@ async fn test_get_many_with_nonexistent_key() {
         );
     }
 
-    let unset_key = "thisisakeythatisntset";
+    let unset_key = "thisisakeythatisnotset";
 
     keys.push(unset_key);
 
     let results = client.get_multi(&keys).await.unwrap();
 
-    assert_eq!(keys.len(), results.len());
+    assert_eq!(original_keys_length, results.len());
 
-    let unset_key_result = results.get(&unset_key);
-
-    // 'None' response is included in the results HashMap for a cache miss
-    assert!(matches!(unset_key_result, Some(Ok(None))));
+    // Hashmap should only contain keys that have a cache hit
+    assert!(!results.contains_key(unset_key.as_bytes()));
 
     for result in results {
-        if let Some(value) = result.1.expect("should have unwrapped a Result") {
+        if let Some(value) = result.1.expect("should have unwrapped to a Value") {
             let key_str = std::str::from_utf8(&value.key)
                 .expect("should have been able to parse key as utf8");
             assert!(keys.clone().contains(&key_str));
         }
     }
+}
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+async fn test_get_many_aliases_get_multi_properly() {
+    let keys = vec!["mg2-key1", "mg2-key2", "mg2-key3"];
+    let values = vec!["value1", "value2", "value3"];
+
+    let mut client = setup_client(&keys).await;
+
+    for (key, value) in keys.iter().zip(values.iter()) {
+        let result = client.set(*key, *value, None, None).await;
+        assert!(result.is_ok(), "failed to set {}, {:?}", key, result);
+    }
+
+    #[allow(deprecated)] // specifically testing deprecated functionality
+    let result = client.get_many(&keys).await;
+
+    assert!(
+        result.is_ok(),
+        "failed to get many {:?}, {:?}",
+        keys,
+        result
+    );
+    assert_eq!(result.unwrap().len(), keys.len());
 }
 
 #[ignore = "Relies on a running memcached server"]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -263,7 +263,7 @@ async fn test_get_multi_with_nonexistent_key() {
     let mut client = setup_client(&keys).await;
 
     for (key, value) in keys.iter().zip(values.iter()) {
-        let set_result = client.set(*key, *value, None, None).await;
+        let set_result = client.set(key, *value, None, None).await;
         assert!(
             set_result.is_ok(),
             "failed to set {}, {:?}",
@@ -280,15 +280,10 @@ async fn test_get_multi_with_nonexistent_key() {
 
     assert_eq!(original_keys_length, results.len());
 
-    // Hashmap should only contain keys that have a cache hit
-    assert!(!results.contains_key(unset_key.as_bytes()));
-
     for result in results {
-        if let Some(value) = result.1.expect("should have unwrapped to a Value") {
-            let key_str = std::str::from_utf8(&value.key)
-                .expect("should have been able to parse key as utf8");
-            assert!(keys.clone().contains(&key_str));
-        }
+        let key_str = std::str::from_utf8(&result.key)
+            .expect("should have been able to parse Value.key as utf8");
+        assert!(&keys.contains(&key_str));
     }
 }
 
@@ -305,7 +300,7 @@ async fn test_get_many_aliases_get_multi_properly() {
         assert!(result.is_ok(), "failed to set {}, {:?}", key, result);
     }
 
-    #[allow(deprecated)] // specifically testing deprecated functionality
+    #[allow(deprecated)] // specifically testing deprecated method
     let result = client.get_many(&keys).await;
 
     assert!(


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->

### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
This PR will deprecate the existing `get_many` method in favor of `get_multi`.  `get_many` now exists as an alias for `get_multi`, and will be fully removed in a future version.

### Details - How are you making this change?  What are the effects of this change?
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->
closes: https://github.com/Shopify/caching-platform/issues/721

This PR had originally performed additional refactoring to attempt to return a `HashMap<Result<Value, Error>, Error>`, but it's not possible to efficiently map errors on a per-key basis at this level due to how the memcached server returns errors.  If there is an error would be returned from the memcached server, then no `Value`s are returned, even for properly formed keys that would result in a cache hit.  These potential errors must be handled by the client.  As such, the crate method should be left as barebones as possible for performance reasons, so the `Vec<Value>` returned from `get_multi` makes the most sense.
<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
