### PR TITLE
Implement flush_all for the ASCII protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implemented `set_multi` method.
+- Added `flush_all` method to the ASCII protocol
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3"
 tokio = { version = "1.26", default-features = false, features = ["io-util"] }
 async-stream = "0.3"
 url = "2.5.2"
+serial_test = "3.1.1"
 
 [dev-dependencies]
 lazy_static = "1.4"


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->

### TL;DR - What are you trying to accomplish?

Adds the `flush_all` memcached operation to async-memcached. Supports the simple case only, without the optional delay.

[Memcached Protocol for `flush_all`](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L1796-L1818)

### Details - How are you making this change?  What are the effects of this change?
- Add the `flush_all` method that sends the `flush_all` Memcached command
- Uses the `serial_test` crate to mark the `flush_all` test as serial (and others as parallel) to prevent the `flush_all` test from interfering with other tests.

<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->

<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
