### PR TITLE
Make the parser Response be public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,11 @@ pub use self::error::Error;
 
 mod parser;
 use self::parser::{
-    parse_ascii_metadump_response, parse_ascii_response, parse_ascii_stats_response, Response,
+    parse_ascii_metadump_response, parse_ascii_response, parse_ascii_stats_response,
 };
-pub use self::parser::{ErrorKind, KeyMetadata, MetadumpResponse, StatsResponse, Status, Value};
+pub use self::parser::{
+    ErrorKind, KeyMetadata, MetadumpResponse, Response, StatsResponse, Status, Value,
+};
 
 mod value_serializer;
 pub use self::value_serializer::AsMemcachedValue;


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->

### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->

Expose the Response which is part of the returned hashmap of `set_multi` API.

### Details - How are you making this change?  What are the effects of this change?
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->

<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
