### PR TITLE
Implement add_multi for ASCII protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `set_multi` method to the ASCII protocol.
 - Added `flush_all` method to the ASCII protocol.
 - Added `delete_multi_no_reply` method to the ASCII protocol.
+- Added `add_multi` method to the ASCII protocol.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ impl Client {
     /// Attempts to add multiple keys and values through pipelined commands.
     ///
     /// If `ttl` or `flags` are not specified, they will default to 0. The same values for `ttl` and `flags` will be applied to each key.
-    /// Returns a result with a HashMap of keys mapped to the result of the set operation, or an error.
+    /// Returns a result with a HashMap of keys mapped to the result of the add operation, or an error.
     pub async fn add_multi<'a, K, V>(
         &mut self,
         kv: &'a [(K, V)],

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-use async_memcached::{Client, Error, Response, Status};
+use async_memcached::{Client, Error, Status};
 use rand::seq::IteratorRandom;
 use serial_test::{parallel, serial};
 
@@ -164,14 +164,8 @@ async fn test_add_multi_with_a_key_that_already_exists() {
         results[&preset_key],
         Err(Error::Protocol(Status::NotStored))
     ));
-    assert!(matches!(
-        results[&keys[1]].as_ref().expect("expected Response"),
-        Response::Status(Status::Stored)
-    ));
-    assert!(matches!(
-        results[&keys[2]].as_ref().expect("expected Response"),
-        Response::Status(Status::Stored)
-    ));
+    assert!(results[&keys[1]].is_ok());
+    assert!(results[&keys[2]].is_ok());
 
     let get_result = client.get(preset_key).await;
 


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->

### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
This PR adds a `add_multi` method for then memcached ASCII protocol.

### Details - How are you making this change?  What are the effects of this change?
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->
This is based off of the `set_multi` method, and similarly returns a `Result<FxHashMap<&'a K, Result<Response, Error>>, Error>` which will contain `STORED` responses or Err(Error::Protocol(Status::NotStored)) mapped to the related keys.
<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
