### PR TITLE
implement memcached `gat` command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,7 +619,7 @@ impl Client {
     /// If the key is found, `Some(Value)` is returned, describing the metadata and data of the key.
     ///
     /// Otherwise, [`Error`] is returned.
-    pub async fn gat<K>(&mut self, exptime: i32, key: K) -> Result<Option<Value>, Error>
+    pub async fn gat<K>(&mut self, key: K, ttl: Option<i64>) -> Result<Option<Value>, Error>
     where
         K: AsRef<[u8]>,
     {
@@ -627,7 +627,8 @@ impl Client {
             .write_all(
                 &[
                     b"gat ",
-                    format!("{exptime} ").as_bytes(),
+                    ttl.unwrap_or(0).to_string().as_bytes(),
+                    b" ",
                     key.as_ref(),
                     b"\r\n",
                 ]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -874,7 +874,7 @@ async fn test_gat_with_nonexistent_key() {
 
     let mut client = setup_client(&[key]).await;
 
-    let get_result = client.gat(0, key).await;
+    let get_result = client.gat(key, None).await;
 
     assert!(matches!(get_result, Ok(None)), "key should not be found");
 }
@@ -896,7 +896,7 @@ async fn test_gat_with_cached_key() {
         set_result
     );
 
-    let get_result = client.gat(-1, key).await;
+    let get_result = client.gat(key, Some(-1)).await;
 
     assert!(
         get_result.is_ok(),


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->
- Done 
### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
- I try add `gat` command for your memcached client

### Details - How are you making this change?  What are the effects of this change?
- It is now possible to use the gat command
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->
- [link on doc with `gat` command](https://github.com/memcached/memcached/blob/5609673ed29db98a377749fab469fe80777de8fd/doc/protocol.txt#L431)
<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
- test PR
<!-- Version to bump to: -->
- not yet
<!-- PR(s) covered by this crate version bump: -->
- not yet
<!-- output of `cargo release <LEVEL> -v` dryrun: -->
- not yet