### PR TITLE
resolve incorrect building msg, build message in one await buffer, cmd `get_multi`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,12 +168,14 @@ impl Client {
         I: IntoIterator<Item = K>,
         K: AsRef<[u8]>,
     {
-        self.conn.write_all(b"get ").await?;
+        let mut bf = Vec::new();
+        bf.extend(b"get");
         for key in keys {
-            self.conn.write_all(key.as_ref()).await?;
-            self.conn.write_all(b" ").await?;
+            bf.extend(b" ");
+            bf.extend(key.as_ref());
         }
-        self.conn.write_all(b"\r\n").await?;
+        bf.extend(b"\r\n");
+        self.conn.write_all(&bf).await?;
         self.conn.flush().await?;
 
         match self.get_read_write_response().await? {


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->
- done formatting
### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
- i fix incorrect building vector with bytes
- send before `get k1 k2 \rn` with extra space, send after fix `get k1 k2\rn` without space
### Details - How are you making this change?  What are the effects of this change?
- only one await send buffer
- fix building message
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->

<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
