### PR TITLE
Add memcached service so integration tests can run during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - 11211:11211
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Run parser and connectiontests
+      - name: Run parser and connection tests
         run: cargo test --all-features
       - name: Run integration tests
         run: cargo test -- --test-threads=1 --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,15 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      memcached:
+        image: memcached:latest
+        ports:
+          - 11211:11211
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Run tests
-        run: cargo test --all-features
-
+        run: cargo test --all-features -- --test-threads=1
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
         run: cargo clippy --benches --all-features
       - name: Run clippy (examples)
         run: cargo clippy --examples --all-features
-
   test:
     runs-on: ubuntu-latest
     services:
@@ -36,8 +35,10 @@ jobs:
           - 11211:11211
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Run tests
-        run: cargo test --all-features -- --test-threads=1
+      - name: Run parser and connectiontests
+        run: cargo test --all-features
+      - name: Run integration tests
+        run: cargo test -- --test-threads=1 --ignored
   build:
     runs-on: ubuntu-latest
     steps:
@@ -46,3 +47,4 @@ jobs:
         run: cargo build --release --all-features
       - name: Build (examples)
         run: cargo build --release --examples --all-features
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ futures = "0.3"
 tokio = { version = "1.26", default-features = false, features = ["io-util"] }
 async-stream = "0.3"
 url = "2.5.2"
-serial_test = "3.1.1"
 fxhash = "0.2.1"
 
 [dev-dependencies]
@@ -29,6 +28,7 @@ lazy_static = "1.4"
 tokio = { version = "1.26", features = ["full"] }
 rand = "0.8"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
+serial_test = "3.1.1"
 
 [features]
 default = []

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -22,6 +22,7 @@ async fn setup_client(keys: &[&str]) -> Client {
     client
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_get_with_cached_key() {
@@ -48,6 +49,7 @@ async fn test_get_with_cached_key() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_get_with_nonexistent_key() {
@@ -60,10 +62,11 @@ async fn test_get_with_nonexistent_key() {
     assert!(matches!(get_result, Ok(None)), "key should not be found");
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_with_string_value() {
-    let key = "async-memcache-test-key-add";
+    let key = "async-memcache-test-key-add-string";
 
     let mut client = setup_client(&[key]).await;
 
@@ -72,6 +75,7 @@ async fn test_add_with_string_value() {
     assert!(result.is_ok(), "failed to add {}, {:?}", key, result);
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_with_u64_value() {
@@ -85,10 +89,11 @@ async fn test_add_with_u64_value() {
     assert!(result.is_ok(), "failed to add {}, {:?}", key, result);
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_with_a_key_that_already_exists() {
-    let key = "async-memcache-test-key-add";
+    let key = "async-memcache-test-key-add-exists";
 
     let mut client = setup_client(&[key]).await;
 
@@ -102,6 +107,7 @@ async fn test_add_with_a_key_that_already_exists() {
     assert_eq!(add_result, Err(Error::Protocol(Status::NotStored)));
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_multi() {
@@ -121,6 +127,7 @@ async fn test_add_multi() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_multi_with_a_key_that_already_exists() {
@@ -172,6 +179,7 @@ async fn test_add_multi_with_a_key_that_already_exists() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_with_string_value() {
@@ -205,6 +213,7 @@ async fn test_set_with_string_value() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_with_string_ref_value() {
@@ -236,6 +245,7 @@ async fn test_set_with_string_ref_value() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_with_u64_value() {
@@ -263,6 +273,7 @@ async fn test_set_with_u64_value() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_fails_with_value_too_large() {
@@ -287,6 +298,7 @@ async fn test_set_fails_with_value_too_large() {
     assert!(matches!(get_result, Ok(None)));
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_get_multi() {
@@ -311,6 +323,7 @@ async fn test_get_multi() {
     assert_eq!(result.unwrap().len(), keys.len());
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_get_multi_with_nonexistent_key() {
@@ -346,7 +359,9 @@ async fn test_get_multi_with_nonexistent_key() {
     }
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
+#[parallel]
 async fn test_get_many_aliases_get_multi_properly() {
     let keys = vec!["get-many-key1", "get-many-key2", "get-many-key3"];
     let values = vec!["value1", "value2", "value3"];
@@ -370,6 +385,7 @@ async fn test_get_many_aliases_get_multi_properly() {
     assert_eq!(result.unwrap().len(), keys.len());
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_delete() {
@@ -411,6 +427,7 @@ async fn test_delete() {
     assert!(result.is_ok(), "failed to delete {}, {:?}", key, result);
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_delete_no_reply() {
@@ -457,6 +474,7 @@ async fn test_delete_no_reply() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_delete_multi_no_reply() {
@@ -477,6 +495,7 @@ async fn test_delete_multi_no_reply() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_multi_with_string_values() {
@@ -503,6 +522,7 @@ async fn test_set_multi_with_string_values() {
     ));
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_multi_with_string_values_that_exceed_max_size() {
@@ -615,6 +635,7 @@ async fn test_set_multi_with_string_values_that_exceed_max_size() {
     }
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_multi_with_large_string_values() {
@@ -636,6 +657,7 @@ async fn test_set_multi_with_large_string_values() {
     assert!(get_result.is_ok());
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increment_raises_error_when_key_doesnt_exist() {
@@ -650,6 +672,7 @@ async fn test_increment_raises_error_when_key_doesnt_exist() {
     assert!(matches!(result, Err(Error::Protocol(Status::NotFound))));
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increments_existing_key() {
@@ -668,6 +691,7 @@ async fn test_increments_existing_key() {
     assert_eq!(Ok(2), result);
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increment_on_non_numeric_value() {
@@ -691,6 +715,7 @@ async fn test_increment_on_non_numeric_value() {
     ));
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increment_can_overflow() {
@@ -715,6 +740,7 @@ async fn test_increment_can_overflow() {
     assert_eq!(Ok(1), result);
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increments_existing_key_with_no_reply() {
@@ -741,6 +767,7 @@ async fn test_increments_existing_key_with_no_reply() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_decrement_raises_error_when_key_doesnt_exist() {
@@ -755,6 +782,7 @@ async fn test_decrement_raises_error_when_key_doesnt_exist() {
     assert!(matches!(result, Err(Error::Protocol(Status::NotFound))));
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_decrements_existing_key() {
@@ -773,6 +801,7 @@ async fn test_decrements_existing_key() {
     assert_eq!(Ok(9), result);
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_decrement_does_not_reduce_value_below_zero() {
@@ -791,6 +820,7 @@ async fn test_decrement_does_not_reduce_value_below_zero() {
     assert_eq!(Ok(0), result);
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_decrements_existing_key_with_no_reply() {
@@ -817,6 +847,7 @@ async fn test_decrements_existing_key_with_no_reply() {
     );
 }
 
+#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[serial]
 async fn test_flush_all() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -22,7 +22,6 @@ async fn setup_client(keys: &[&str]) -> Client {
     client
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_get_with_cached_key() {
@@ -49,7 +48,6 @@ async fn test_get_with_cached_key() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_get_with_nonexistent_key() {
@@ -62,7 +60,6 @@ async fn test_get_with_nonexistent_key() {
     assert!(matches!(get_result, Ok(None)), "key should not be found");
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_with_string_value() {
@@ -75,7 +72,6 @@ async fn test_add_with_string_value() {
     assert!(result.is_ok(), "failed to add {}, {:?}", key, result);
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_with_u64_value() {
@@ -89,7 +85,6 @@ async fn test_add_with_u64_value() {
     assert!(result.is_ok(), "failed to add {}, {:?}", key, result);
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_with_a_key_that_already_exists() {
@@ -107,7 +102,6 @@ async fn test_add_with_a_key_that_already_exists() {
     assert_eq!(add_result, Err(Error::Protocol(Status::NotStored)));
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_multi() {
@@ -127,7 +121,6 @@ async fn test_add_multi() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_add_multi_with_a_key_that_already_exists() {
@@ -179,7 +172,6 @@ async fn test_add_multi_with_a_key_that_already_exists() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_with_string_value() {
@@ -213,7 +205,6 @@ async fn test_set_with_string_value() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_with_string_ref_value() {
@@ -245,7 +236,6 @@ async fn test_set_with_string_ref_value() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_with_u64_value() {
@@ -273,7 +263,6 @@ async fn test_set_with_u64_value() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_fails_with_value_too_large() {
@@ -298,7 +287,6 @@ async fn test_set_fails_with_value_too_large() {
     assert!(matches!(get_result, Ok(None)));
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_get_multi() {
@@ -323,7 +311,6 @@ async fn test_get_multi() {
     assert_eq!(result.unwrap().len(), keys.len());
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_get_multi_with_nonexistent_key() {
@@ -359,10 +346,9 @@ async fn test_get_multi_with_nonexistent_key() {
     }
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 async fn test_get_many_aliases_get_multi_properly() {
-    let keys = vec!["mg2-key1", "mg2-key2", "mg2-key3"];
+    let keys = vec!["get-many-key1", "get-many-key2", "get-many-key3"];
     let values = vec!["value1", "value2", "value3"];
 
     let mut client = setup_client(&keys).await;
@@ -384,7 +370,6 @@ async fn test_get_many_aliases_get_multi_properly() {
     assert_eq!(result.unwrap().len(), keys.len());
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_delete() {
@@ -426,7 +411,6 @@ async fn test_delete() {
     assert!(result.is_ok(), "failed to delete {}, {:?}", key, result);
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_delete_no_reply() {
@@ -473,7 +457,6 @@ async fn test_delete_no_reply() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_delete_multi_no_reply() {
@@ -494,7 +477,6 @@ async fn test_delete_multi_no_reply() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_multi_with_string_values() {
@@ -521,7 +503,6 @@ async fn test_set_multi_with_string_values() {
     ));
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_multi_with_string_values_that_exceed_max_size() {
@@ -634,7 +615,6 @@ async fn test_set_multi_with_string_values_that_exceed_max_size() {
     }
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_set_multi_with_large_string_values() {
@@ -656,7 +636,6 @@ async fn test_set_multi_with_large_string_values() {
     assert!(get_result.is_ok());
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increment_raises_error_when_key_doesnt_exist() {
@@ -671,7 +650,6 @@ async fn test_increment_raises_error_when_key_doesnt_exist() {
     assert!(matches!(result, Err(Error::Protocol(Status::NotFound))));
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increments_existing_key() {
@@ -690,7 +668,6 @@ async fn test_increments_existing_key() {
     assert_eq!(Ok(2), result);
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increment_on_non_numeric_value() {
@@ -714,7 +691,6 @@ async fn test_increment_on_non_numeric_value() {
     ));
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increment_can_overflow() {
@@ -739,7 +715,6 @@ async fn test_increment_can_overflow() {
     assert_eq!(Ok(1), result);
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_increments_existing_key_with_no_reply() {
@@ -766,7 +741,6 @@ async fn test_increments_existing_key_with_no_reply() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_decrement_raises_error_when_key_doesnt_exist() {
@@ -781,7 +755,6 @@ async fn test_decrement_raises_error_when_key_doesnt_exist() {
     assert!(matches!(result, Err(Error::Protocol(Status::NotFound))));
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_decrements_existing_key() {
@@ -800,7 +773,6 @@ async fn test_decrements_existing_key() {
     assert_eq!(Ok(9), result);
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_decrement_does_not_reduce_value_below_zero() {
@@ -819,7 +791,6 @@ async fn test_decrement_does_not_reduce_value_below_zero() {
     assert_eq!(Ok(0), result);
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[parallel]
 async fn test_decrements_existing_key_with_no_reply() {
@@ -846,7 +817,6 @@ async fn test_decrements_existing_key_with_no_reply() {
     );
 }
 
-#[ignore = "Relies on a running memcached server"]
 #[tokio::test]
 #[serial]
 async fn test_flush_all() {


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->

### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
Add a `memcached` service to our github actions CI so that integration tests can run on each pull request

### Details - How are you making this change?  What are the effects of this change?
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->
closes: https://github.com/Shopify/async-memcached/issues/14

Updated `./github/workflows/ci.yml`.  Running the tests that rely on a `memcached` server with `--test-threads=1` to avoid potential flakiness issues.

<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
