### PR TITLE
generate message and await once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,27 +213,25 @@ impl Client {
         K: AsRef<[u8]>,
         V: AsMemcachedValue,
     {
-        let kr = key.as_ref();
         let vr = value.as_bytes();
-
-        self.conn.write_all(b"set ").await?;
-        self.conn.write_all(kr).await?;
-
-        let flags = flags.unwrap_or(0).to_string();
-        self.conn.write_all(b" ").await?;
-        self.conn.write_all(flags.as_ref()).await?;
-
-        let ttl = ttl.unwrap_or(0).to_string();
-        self.conn.write_all(b" ").await?;
-        self.conn.write_all(ttl.as_ref()).await?;
-
-        let vlen = vr.len().to_string();
-        self.conn.write_all(b" ").await?;
-        self.conn.write_all(vlen.as_ref()).await?;
-        self.conn.write_all(b"\r\n").await?;
-
-        self.conn.write_all(vr.as_ref()).await?;
-        self.conn.write_all(b"\r\n").await?;
+        self.conn
+            .write_all(
+                &[
+                    b"set ",
+                    key.as_ref(),
+                    b" ",
+                    flags.unwrap_or(0).to_string().as_ref(),
+                    b" ",
+                    ttl.unwrap_or(0).to_string().as_ref(),
+                    b" ",
+                    vr.len().to_string().as_ref(),
+                    b"\r\n",
+                    vr.as_ref(),
+                    b"\r\n",
+                ]
+                .concat(),
+            )
+            .await?;
 
         self.conn.flush().await?;
 


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->
- Going format
### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
- change send message in `set` command, generate message and await once
### Details - How are you making this change?  What are the effects of this change?
- now we don’t wait for a message to be generated every time
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->

<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
