### PR TITLE
try append noreply arg?

### DIFF
--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -41,12 +41,12 @@ async fn main() {
         ),
     }
 
-    match client.delete("foo").await {
+    match client.delete("foo", false).await {
         Ok(()) => println!("deleted 'foo' successfully"),
         Err(status) => println!("got status during 'foo' delete: {:?}", status),
     }
 
-    match client.delete_no_reply("foo").await {
+    match client.delete("foo", true).await {
         Ok(()) => println!("deleted_no_reply 'foo' successfully"),
         Err(status) => println!("got status during 'foo' deleted_no_reply: {:?}", status),
     }

--- a/examples/unix.rs
+++ b/examples/unix.rs
@@ -40,12 +40,12 @@ async fn main() {
         ),
     }
 
-    match client.delete("foo").await {
+    match client.delete("foo", true).await {
         Ok(()) => println!("deleted 'foo' successfully"),
         Err(status) => println!("got status during 'foo' delete: {:?}", status),
     }
 
-    match client.delete_no_reply("add_key").await {
+    match client.delete("add_key", false).await {
         Ok(()) => println!("deleted_no_reply 'add_key' successfully"),
         Err(status) => println!("got status during 'add_key' deleted_no_reply: {:?}", status),
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -14,7 +14,7 @@ async fn setup_client(keys: &[&str]) -> Client {
 
     for key in keys {
         client
-            .delete_no_reply(key)
+            .delete(key, true)
             .await
             .expect("Failed to delete key");
     }
@@ -422,7 +422,7 @@ async fn test_delete() {
         None => panic!("failed to get {}", key),
     }
 
-    let result = client.delete(key).await;
+    let result = client.delete(key, false).await;
 
     assert!(result.is_ok(), "failed to delete {}, {:?}", key, result);
 }
@@ -464,7 +464,7 @@ async fn test_delete_no_reply() {
         None => panic!("failed to get {}", key),
     }
 
-    let delete_result = client.delete_no_reply(key).await;
+    let delete_result = client.delete(key, true).await;
 
     assert!(
         delete_result.is_ok(),


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->
- Done formating
### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
- change signature and body command delete with noreply arg, type bool 
### Details - How are you making this change?  What are the effects of this change?
I would like to suggest that you explicitly specify the noreply parameter because it is a parameter for the command, not a separate command. It also makes sense because otherwise you need a 2-copy implementation for all `Retrieval` and `Delete` commands that can include this flag.

The amount of code otherwise grows progressively, along with fixes.

But what I don't like about my solution? Two separate functions with different flags are easier to read, lighter, stricter and more stable.

There is a compromise between the strict implementation of all separate functions with different parameters, which ensures reliability, and on the other hand, an API similar to memcached and a reduction in code.

What do you think about this?
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->

<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
