### PR TITLE
FIX: resolve problem - miss exptime for flush_all command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,14 +594,19 @@ impl Client {
         Ok(entries)
     }
 
-    /// Flushes all existing items on the server
+    /// Flushes all existing items on the server with optional expire time
     ///
     /// This operation invalidates all existing items immediately. Any items with an update time
     /// older than the time of the flush_all operation will be ignored for retrieval purposes.
     /// This operation does not free up memory taken up by the existing items.
-
-    pub async fn flush_all(&mut self) -> Result<(), Error> {
-        self.conn.write_all(b"flush_all\r\n").await?;
+    pub async fn flush_all(&mut self, ttl: Option<i64>) -> Result<(), Error> {
+        let exptime = match ttl {
+            None => String::new(),
+            Some(t) => format!(" {t}"),
+        };
+        self.conn
+            .write_all(&[b"flush_all", exptime.as_bytes(), b"\r\n"].concat())
+            .await?;
         self.conn.flush().await?;
 
         let mut response = String::new();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -851,7 +851,7 @@ async fn test_decrements_existing_key_with_no_reply() {
 #[tokio::test]
 #[serial]
 async fn test_flush_all() {
-    let key = "flush-all-key";
+    let key = "test_flush_all";
     let value: u64 = 1;
 
     let mut client = setup_client(&[key]).await;
@@ -860,7 +860,7 @@ async fn test_flush_all() {
     let result = client.get(key).await;
     assert!(result.is_ok());
 
-    let result = client.flush_all().await;
+    let result = client.flush_all(None).await;
     assert!(result.is_ok());
 
     let result = client.get(key).await;


### PR DESCRIPTION
- memcached signature `flush_all <option exptime> <option noreply>`

<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->

### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
- An optional exptime argument was proposed for the flush_all command. Now it is there, this corresponds to the semantics of the memcached command
### Details - How are you making this change?  What are the effects of this change?
- insert ttl in func and update tests, doc
- [look flush_all with args](https://github.com/memcached/memcached/blob/5609673ed29db98a377749fab469fe80777de8fd/doc/protocol.txt#L1796)
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->

<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
