### PR TITLE
FEATURE:implement `flush_all noreply`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,6 +615,24 @@ impl Client {
             )))))
         }
     }
+
+    /// Flushes all existing items with no reply from server
+    ///
+    /// This operation invalidates all existing items immediately. Any items with an update time
+    /// older than the time of the flush_all operation will be ignored for retrieval purposes.
+    /// This operation does not free up memory taken up by the existing items.
+    pub async fn flush_all_noreply(&mut self, ttl: Option<i64>) -> Result<(), Error> {
+        let exptime = match ttl {
+            None => String::new(),
+            Some(t) => format!(" {t}"),
+        };
+        self.conn
+            .write_all(&[b"flush_all", exptime.as_bytes(), b" noreply\r\n"].concat())
+            .await?;
+        self.conn.flush().await?;
+
+        Ok(())
+    }
 }
 
 /// Asynchronous iterator for metadump operations.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -866,3 +866,23 @@ async fn test_flush_all() {
     let result = client.get(key).await;
     assert!(matches!(result, Ok(None)));
 }
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+#[serial]
+async fn test_flush_all_noreply() {
+    let key = "test_flush_all_noreply";
+    let value: u64 = 1;
+
+    let mut client = setup_client(&[key]).await;
+
+    let _ = client.set(key, value, None, None).await;
+    let result = client.get(key).await;
+    assert!(result.is_ok());
+
+    let result = client.flush_all_noreply(None).await;
+    assert!(result.is_ok());
+
+    let result = client.get(key).await;
+    assert_eq!(result, Ok(None));
+}


### PR DESCRIPTION
<!-- ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors -->

### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
- copy flush_all command but with noreply option
### Details - How are you making this change?  What are the effects of this change?
- implement flashs(expire) keys without await response memcached
- [flush_all](https://github.com/memcached/memcached/blob/5609673ed29db98a377749fab469fe80777de8fd/doc/protocol.txt#L1796)
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Provide benchmark results if possible to show any perf differences. -->

<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
