### PR TITLE
Implement Meta Get functionality

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 ### Details - How are you making this change?  What are the effects of this change?
 <!-- If this is a PR for a new feature, changed feature or a bug fix: -->
 <!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
-<!-- If you are propsing changes to existing code, please run `cargo bench` against main branch and your feature branch. -->
+<!-- If you are proposing changes to existing code, please run `cargo bench` against main branch and your feature branch. -->
 <!-- Include results of your benchmarks in a code block in this section to show performance changes. -->
 
 <!-- -------------------------------------------- -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors. -->
+<!-- Ensure you have run `cargo fmt` and `cargo clippy --tests --all-features` to catch linting errors. -->
 <!-- Update CHANGELOG.md with with any changes included in this PR. -->
 ### TL;DR - What are you trying to accomplish?
 <!-- One or two line summary of your change-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `Toxiproxy` resiliency testing.
 - Added crate-level validation for key lengths.  Allowing a key that is too long through to the memcached protocol can lead to multiple errors being returned for a single operation, which leaves unexpected and unread bytes on the buffer.  Future operations can be parsed incorrectly if this is left unchecked, but validating key length is a simple check to prevent this behaviour.
+- Added parsing capabilities for Meta Get and Meta Set operations, with support for all flags.
 
 ### Changed
 - Refactored some wall-clock benchmarks to yield more realistic results for expensive set operations.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -34,6 +34,48 @@ fn bench_get(c: &mut Criterion) {
     });
 }
 
+fn bench_meta_get(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    rt.block_on(async {
+        let mut client = setup_client().await;
+        client.set("foo", "bar", None, None).await.unwrap();
+    });
+
+    c.bench_function("bench meta_get", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut client = setup_client().await;
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client.meta_get("foo", Some(&["v", "h", "t", "l"])).await;
+            }
+            start.elapsed()
+        });
+    });
+}
+
+fn bench_meta_get_concat(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    rt.block_on(async {
+        let mut client = setup_client().await;
+        client.set("foo", "bar", None, None).await.unwrap();
+    });
+
+    c.bench_function("bench meta_get_concat", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let mut client = setup_client().await;
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client
+                    .meta_get_concat("foo", Some(&["v", "h", "t", "l"]))
+                    .await;
+            }
+            start.elapsed()
+        });
+    });
+}
+
 fn bench_set_with_small_string(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
@@ -306,6 +348,8 @@ fn bench_decrement_no_reply(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_get,
+    bench_meta_get,
+    bench_meta_get_concat,
     bench_get_multi,
     bench_get_large,
     bench_get_many_large,

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -18,14 +18,10 @@ async fn setup_client() -> Client {
 fn bench_get_small(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
-    rt.block_on(async {
-        let mut client = setup_client().await;
-        client.set("foo", "bar", None, None).await.unwrap();
-    });
-
-    c.bench_function("bench ascii get small key and small value", |b| {
+    c.bench_function("bench ascii get with small key and small value", |b| {
         b.to_async(&rt).iter_custom(move |iters| async move {
             let mut client = setup_client().await;
+            client.set("foo", "bar", None, None).await.unwrap();
             let start = std::time::Instant::now();
             for _ in 0..iters {
                 let _ = client.get("foo").await;
@@ -38,20 +34,13 @@ fn bench_get_small(c: &mut Criterion) {
 fn bench_get_large(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
-    let key = "a".repeat(MAX_KEY_LENGTH);
-    let value = "b".repeat(LARGE_PAYLOAD_SIZE);
-
-    rt.block_on(async {
-        let mut client = setup_client().await;
-        client.set(&key, &value, None, None).await.unwrap();
-    });
-
-    c.bench_function("bench ascii get", |b| {
-        let key_clone = key.clone();
+    c.bench_function("bench ascii get with large key and large value", |b| {
         b.to_async(&rt).iter_custom(move |iters| {
-            let key = key_clone.clone();
+            let key = "a".repeat(MAX_KEY_LENGTH);
+            let value = "b".repeat(LARGE_PAYLOAD_SIZE);
             async move {
                 let mut client = setup_client().await;
+                client.set(&key, &value, None, None).await.unwrap();
                 let start = std::time::Instant::now();
                 for _ in 0..iters {
                     let _ = client.get(&key).await;
@@ -65,14 +54,10 @@ fn bench_get_large(c: &mut Criterion) {
 fn bench_meta_get_small(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
-    rt.block_on(async {
-        let mut client = setup_client().await;
-        client.set("foo", "bar", None, None).await.unwrap();
-    });
-
     c.bench_function("bench meta_get with small key and small value", |b| {
         b.to_async(&rt).iter_custom(move |iters| async move {
             let mut client = setup_client().await;
+            client.set("foo", "bar", None, None).await.unwrap();
             let start = std::time::Instant::now();
             for _ in 0..iters {
                 let _ = client.meta_get("foo", Some(&["v", "h", "t", "l"])).await;
@@ -85,27 +70,21 @@ fn bench_meta_get_small(c: &mut Criterion) {
 fn bench_meta_get_large(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
-    let key = "a".repeat(MAX_KEY_LENGTH);
-    let value = "b".repeat(LARGE_PAYLOAD_SIZE);
-
-    rt.block_on(async {
-        let mut client = setup_client().await;
-        client.set(&key, &value, None, None).await.unwrap();
-    });
-
     c.bench_function("bench meta_get with large key and large value", |b| {
-        let key_clone = key.clone();
-        b.to_async(&rt).iter_custom(move |iters| {
-            let key = key_clone.clone();
-            async move {
-                let mut client = setup_client().await;
-                let start = std::time::Instant::now();
-                for _ in 0..iters {
-                    let _ = client.meta_get(&key, Some(&["v", "h", "t", "l"])).await;
-                }
-                start.elapsed()
+        b.to_async(&rt).iter_custom(move |iters| async move {
+            let key = "a".repeat(MAX_KEY_LENGTH);
+            let value = "b".repeat(LARGE_PAYLOAD_SIZE);
+
+            let mut client = setup_client().await;
+
+            client.set(&key, &value, None, None).await.unwrap();
+
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let _ = client.meta_get(&key, Some(&["v", "h", "t", "l"])).await;
             }
-        })
+            start.elapsed()
+        });
     });
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,7 @@ use tokio::runtime::Runtime;
 use std::env;
 
 const MAX_KEY_LENGTH: usize = 250;
-const LARGE_PAYLOAD_SIZE: usize = 1000 * 1024; // Memcached's ~default maximum payload size
+const LARGE_PAYLOAD_SIZE: usize = 1024 * 1024 - 310; // Memcached's default maximum payload size ~1MB minus max key length + metadata
 
 async fn setup_client() -> Client {
     let memcached_host = env::var("MEMCACHED_HOST").unwrap_or("127.0.0.1".to_string());

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -109,35 +109,6 @@ fn bench_meta_get_large(c: &mut Criterion) {
     });
 }
 
-fn bench_meta_get_concat(c: &mut Criterion) {
-    let rt = Runtime::new().unwrap();
-
-    let key = "a".repeat(MAX_KEY_LENGTH);
-    let value = "b".repeat(LARGE_PAYLOAD_SIZE);
-
-    rt.block_on(async {
-        let mut client = setup_client().await;
-        client.set(&key, &value, None, None).await.unwrap();
-    });
-
-    c.bench_function("bench meta_get_concat", |b| {
-        let key_clone = key.clone();
-        b.to_async(&rt).iter_custom(move |iters| {
-            let key = key_clone.clone();
-            async move {
-                let mut client = setup_client().await;
-                let start = std::time::Instant::now();
-                for _ in 0..iters {
-                    let _ = client
-                        .meta_get_concat(&key, Some(&["v", "h", "t", "l"]))
-                        .await;
-                }
-                start.elapsed()
-            }
-        })
-    });
-}
-
 fn bench_set_with_small_string(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
@@ -389,7 +360,6 @@ criterion_group!(
     bench_get_large,
     bench_meta_get_small,
     bench_meta_get_large,
-    bench_meta_get_concat,
     bench_get_multi,
     bench_get_many_large,
     bench_set_with_small_string,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use self::error::Error;
 mod parser;
 use self::parser::{
     parse_ascii_metadump_response, parse_ascii_response, parse_ascii_stats_response,
-    parse_meta_response,
+    parse_meta_get_response,
 };
 pub use self::parser::{
     ErrorKind, KeyMetadata, MetadumpResponse, Response, StatsResponse, Status, Value,
@@ -243,7 +243,7 @@ impl Client {
         self.conn.write_all(b"\r\n").await?;
         self.conn.flush().await?;
 
-        match self.drive_receive(parse_meta_response).await? {
+        match self.drive_receive(parse_meta_get_response).await? {
             Response::Status(Status::NotFound) => Ok(None),
             Response::Status(s) => Err(s.into()),
             Response::Data(d) => d
@@ -289,7 +289,7 @@ impl Client {
         self.conn.write_all(&command).await?;
         self.conn.flush().await?;
 
-        match self.drive_receive(parse_meta_response).await? {
+        match self.drive_receive(parse_meta_get_response).await? {
             Response::Status(Status::NotFound) => Ok(None),
             Response::Status(s) => Err(s.into()),
             Response::Data(d) => d

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,51 @@ impl Client {
         }
     }
 
+    /// Gets the given key with additional metadata.
+    ///
+    /// If the key is found, `Some(Value)` is returned, describing the metadata and data of the key.
+    ///
+    /// Otherwise, `None` is returned.
+    ///
+    /// Supported meta flags:
+    /// - v: return item value
+    /// - h: return whether item has been hit before as a 0 or 1
+    /// - l: return time since item was last accessed in seconds
+    /// - t: return item TTL remaining in seconds (-1 for unlimited)
+    pub async fn meta_get_concat<K: AsRef<[u8]>>(
+        &mut self,
+        key: K,
+        meta_flags: &[&str], // meta_get should always have at least one flag, otherwise it's a no-op
+    ) -> Result<Option<Value>, Error> {
+        let command_length: usize = MAX_KEY_LENGTH + 2 * meta_flags.len() + 5; // key + flags & whitespaces + "mg " + "\r\n"
+        let mut command = Vec::with_capacity(command_length);
+        command.extend_from_slice(b"mg ");
+        command.extend_from_slice(key.as_ref());
+        command.extend_from_slice(b" ");
+        command.extend_from_slice(meta_flags.join(" ").as_bytes());
+        command.extend_from_slice(b"\r\n");
+        // println!("command: {:?}", String::from_utf8_lossy(&command));
+        self.conn.write_all(&command).await?;
+        self.conn.flush().await?;
+
+        match self.drive_receive(parse_meta_response).await? {
+            Response::Status(Status::NotFound) => Ok(None),
+            Response::Status(s) => Err(s.into()),
+            Response::Data(d) => d
+                .map(|mut items| {
+                    if items.len() != 1 {
+                        Err(Status::Error(ErrorKind::Protocol(None)).into())
+                    } else {
+                        let mut item = items.remove(0);
+                        item.key = key.as_ref().to_vec();
+                        Ok(item)
+                    }
+                })
+                .transpose(),
+            _ => Err(Error::Protocol(Status::Error(ErrorKind::Protocol(None)))),
+        }
+    }
+
     /// Sets the given key.
     ///
     /// If `ttl` or `flags` are not specified, they will default to 0.  If the value is set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,14 @@ use self::parser::{
     parse_ascii_metadump_response, parse_ascii_response, parse_ascii_stats_response,
     parse_meta_response,
 };
-pub use self::parser::{ErrorKind, KeyMetadata, MetadumpResponse, Response, StatsResponse, Status, Value};
+pub use self::parser::{
+    ErrorKind, KeyMetadata, MetadumpResponse, Response, StatsResponse, Status, Value,
+};
 
 mod value_serializer;
 pub use self::value_serializer::AsMemcachedValue;
 
 const MAX_KEY_LENGTH: usize = 250; // reference in memcached documentation: https://github.com/memcached/memcached/blob/5609673ed29db98a377749fab469fe80777de8fd/doc/protocol.txt#L46
-// const MAX_VALUE_SIZE: usize = 1024 * 1024; // 1 MB
 
 /// High-level memcached client.
 ///
@@ -274,8 +275,8 @@ impl Client {
         key: K,
         meta_flags: Option<&[&str]>, // meta_get should always have at least one flag, otherwise it's a no-op
     ) -> Result<Option<Value>, Error> {
-        let command_length: usize = MAX_KEY_LENGTH + 2 * meta_flags.as_ref().map_or(0, |flags| flags.len()) + 5; // key + flags & whitespaces + "mg " + "\r\n"
-        let mut command = Vec::with_capacity(command_length);
+        // let command_length: usize = MAX_KEY_LENGTH + 2 * meta_flags.as_ref().map_or(0, |flags| flags.len()) + 5; // key + flags & whitespaces + "mg " + "\r\n"
+        let mut command = Vec::new();
         command.extend_from_slice(b"mg ");
         command.extend_from_slice(key.as_ref());
         command.extend_from_slice(b" ");
@@ -283,7 +284,6 @@ impl Client {
             command.extend_from_slice(flags.join(" ").as_bytes());
         }
         command.extend_from_slice(b"\r\n");
-        // println!("command: {:?}", String::from_utf8_lossy(&command));
         self.conn.write_all(&command).await?;
         self.conn.flush().await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,9 @@ impl Client {
         meta_flags: Option<&[&str]>,
     ) -> Result<Option<Value>, Error> {
         self.conn.write_all(b"mg ").await?;
-        self.conn.write_all(key.as_ref()).await?;
+        self.conn
+            .write_all(Self::validate_key_length(key.as_ref())?)
+            .await?;
         self.conn.write_all(b" ").await?;
         if let Some(flags) = meta_flags {
             self.conn.write_all(flags.join(" ").as_bytes()).await?;
@@ -278,7 +280,7 @@ impl Client {
         // let command_length: usize = MAX_KEY_LENGTH + 2 * meta_flags.as_ref().map_or(0, |flags| flags.len()) + 5; // key + flags & whitespaces + "mg " + "\r\n"
         let mut command = Vec::new();
         command.extend_from_slice(b"mg ");
-        command.extend_from_slice(key.as_ref());
+        command.extend_from_slice(Self::validate_key_length(key.as_ref())?);
         command.extend_from_slice(b" ");
         if let Some(flags) = meta_flags {
             command.extend_from_slice(flags.join(" ").as_bytes());

--- a/src/parser/meta.rs
+++ b/src/parser/meta.rs
@@ -33,13 +33,13 @@ pub fn parse_meta_get_status(buf: &[u8]) -> IResult<&[u8], Response> {
 }
 
 pub fn parse_meta_get_response(buf: &[u8]) -> Result<Option<(usize, Response)>, ErrorKind> {
-    let bufn = buf.len();
+    let n_bytes_required = buf.len();
     let result = parse_meta_get_data_value(buf);
 
     match result {
-        Ok((left, response)) => {
-            let n = bufn - left.len();
-            Ok(Some((n, response)))
+        Ok((n_bytes_remaining, response)) => {
+            let n_bytes_buffered = n_bytes_required - n_bytes_remaining.len();
+            Ok(Some((n_bytes_buffered, response)))
         }
         Err(nom::Err::Incomplete(_)) => Ok(None),
         Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => {
@@ -50,14 +50,13 @@ pub fn parse_meta_get_response(buf: &[u8]) -> Result<Option<(usize, Response)>, 
 
 #[allow(dead_code)]
 pub fn parse_meta_set_response(buf: &[u8]) -> Result<Option<(usize, Response)>, ErrorKind> {
-    let bufn = buf.len();
-
+    let n_bytes_required = buf.len();
     let result = parse_meta_set_data_value(buf);
 
     match result {
-        Ok((left, response)) => {
-            let n = bufn - left.len();
-            Ok(Some((n, response)))
+        Ok((n_bytes_remaining, response)) => {
+            let n_bytes_buffered = n_bytes_required - n_bytes_remaining.len();
+            Ok(Some((n_bytes_buffered, response)))
         }
         Err(nom::Err::Incomplete(_)) => Ok(None),
         Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => {

--- a/src/parser/meta.rs
+++ b/src/parser/meta.rs
@@ -106,6 +106,7 @@ fn parse_meta_get_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
         Response::Status(Status::Exists) => {
             // no value (data block) or size in this case, potentially just flags
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)?;
+            let (input, _) = crlf(input)?; // consume the trailing crlf and leave the buffer empty
 
             // early return if there were no flags passed in (no-op)
             if meta_values_array.is_empty() {
@@ -122,6 +123,7 @@ fn parse_meta_get_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
         }
         Response::Status(Status::NotFound) => {
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)?;
+            let (input, _) = crlf(input)?; // consume the trailing crlf and leave the buffer empty
 
             // return early if there were no flags passed in (miss without opaque or k flag)
             if meta_values_array.is_empty() {
@@ -153,6 +155,7 @@ fn parse_meta_set_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
             // no value (data block) or size in this case, potentially just flags
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)
                 .map_err(|_| nom::Err::Failure(nom::error::Error::new(buf, Fail)))?;
+            let (input, _) = crlf(input)?; // consume the trailing crlf and leave the buffer empty
 
             // early return if there were no flags passed in
             if meta_values_array.is_empty() {
@@ -171,6 +174,7 @@ fn parse_meta_set_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
             // no value (data block) or size in this case, potentially just flags
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)
                 .map_err(|_| nom::Err::Failure(nom::error::Error::new(buf, Fail)))?;
+            let (input, _) = crlf(input)?; // consume the trailing crlf and leave the buffer empty
 
             // early return if there were no flags passed in
             if meta_values_array.is_empty() {
@@ -188,6 +192,7 @@ fn parse_meta_set_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
         Response::Status(Status::Exists) => {
             // no value (data block) or size in this case, potentially just flags
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)?;
+            let (input, _) = crlf(input)?; // consume the trailing crlf and leave the buffer empty
 
             // early return if there were no flags passed in
             if meta_values_array.is_empty() {
@@ -205,6 +210,7 @@ fn parse_meta_set_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
         Response::Status(Status::NotFound) => {
             // no value (data block) or size in this case, potentially just flags
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)?;
+            let (input, _) = crlf(input)?; // consume the trailing crlf and leave the buffer empty
 
             // early return if there were no flags passed in
             if meta_values_array.is_empty() {

--- a/src/parser/meta.rs
+++ b/src/parser/meta.rs
@@ -21,7 +21,7 @@ pub fn parse_meta_set_status(buf: &[u8]) -> IResult<&[u8], Response> {
         value(Response::Status(Status::NotStored), tag(b"NS")),
         value(Response::Status(Status::Exists), tag(b"EX")),
         value(Response::Status(Status::NotFound), tag(b"NF")),
-        value(Response::Status(Status::NoOp), tag(b"MN")),
+        value(Response::Status(Status::NoOp), tag(b"MN\r\n")),
     ))(buf)
 }
 
@@ -30,18 +30,18 @@ pub fn parse_meta_get_status(buf: &[u8]) -> IResult<&[u8], Response> {
         value(Response::Status(Status::Value), tag(b"VA ")),
         value(Response::Status(Status::Exists), tag(b"HD")),
         value(Response::Status(Status::NotFound), tag(b"EN")),
-        value(Response::Status(Status::NoOp), tag(b"MN")),
+        value(Response::Status(Status::NoOp), tag(b"MN\r\n")),
     ))(buf)
 }
 
 pub fn parse_meta_get_response(buf: &[u8]) -> Result<Option<(usize, Response)>, ErrorKind> {
-    let n_bytes_required = buf.len();
+    let total_bytes = buf.len();
     let result = parse_meta_get_data_value(buf);
 
     match result {
-        Ok((n_bytes_remaining, response)) => {
-            let n_bytes_buffered = n_bytes_required - n_bytes_remaining.len();
-            Ok(Some((n_bytes_buffered, response)))
+        Ok((remaining_bytes, response)) => {
+            let read_bytes = total_bytes - remaining_bytes.len();
+            Ok(Some((read_bytes, response)))
         }
         Err(nom::Err::Incomplete(_)) => Ok(None),
         Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => {
@@ -52,13 +52,13 @@ pub fn parse_meta_get_response(buf: &[u8]) -> Result<Option<(usize, Response)>, 
 
 #[allow(dead_code)]
 pub fn parse_meta_set_response(buf: &[u8]) -> Result<Option<(usize, Response)>, ErrorKind> {
-    let n_bytes_required = buf.len();
+    let total_bytes = buf.len();
     let result = parse_meta_set_data_value(buf);
 
     match result {
-        Ok((n_bytes_remaining, response)) => {
-            let n_bytes_buffered = n_bytes_required - n_bytes_remaining.len();
-            Ok(Some((n_bytes_buffered, response)))
+        Ok((remaining_bytes, response)) => {
+            let read_bytes = total_bytes - remaining_bytes.len();
+            Ok(Some((read_bytes, response)))
         }
         Err(nom::Err::Incomplete(_)) => Ok(None),
         Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => {
@@ -93,10 +93,7 @@ fn parse_meta_get_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
             let (input, size) = parse_u32(input)?; // parses the size of the data from the input
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)?; // parses the flags from the input
             let (input, _) = crlf(input)?; // removes the leading crlf from the data block
-            let (mut input, data) = take_until_size(input, size)?; // parses the data from the input
-            if input == b"MN\r\n" {
-                input = b""; // removes the MN\r\n from the buffer if quiet mode was used
-            }
+            let (input, data) = take_until_size(input, size)?; // parses the data from the input
 
             let value = construct_value_from_meta_values(
                 meta_values_array,

--- a/src/parser/meta.rs
+++ b/src/parser/meta.rs
@@ -4,26 +4,26 @@ use nom::{
     character::streaming::{crlf, space1},
     combinator::{map, value},
     multi::many0,
-    sequence::{terminated, tuple},
+    sequence::tuple,
     IResult,
 };
 
 use super::{parse_u32, ErrorKind, MetaValue, Response, Status, Value};
 use crate::Error;
 
-// TODO: remove this later in favour of individual parse_meta_*_status methods]
-pub fn parse_meta_status(buf: &[u8]) -> IResult<&[u8], Response> {
-    terminated(
-        alt((
-            value(Response::Status(Status::NotStored), tag(b"NS")),
-            value(Response::Status(Status::Deleted), tag(b"DE")),
-            value(Response::Status(Status::Touched), tag(b"TO")),
-            value(Response::Status(Status::Exists), tag(b"EX")),
-            value(Response::Status(Status::NotFound), tag(b"NF")),
-        )),
-        crlf,
-    )(buf)
-}
+// // TODO: remove this later in favour of individual parse_meta_*_status methods]
+// pub fn parse_meta_status(buf: &[u8]) -> IResult<&[u8], Response> {
+//     terminated(
+//         alt((
+//             value(Response::Status(Status::NotStored), tag(b"NS")),
+//             value(Response::Status(Status::Deleted), tag(b"DE")),
+//             value(Response::Status(Status::Touched), tag(b"TO")),
+//             value(Response::Status(Status::Exists), tag(b"EX")),
+//             value(Response::Status(Status::NotFound), tag(b"NF")),
+//         )),
+//         crlf,
+//     )(buf)
+// }
 
 pub fn parse_meta_set_status(buf: &[u8]) -> IResult<&[u8], Response> {
     alt((
@@ -48,7 +48,7 @@ pub fn parse_meta_response(buf: &[u8]) -> Result<Option<(usize, Response)>, Erro
     // TODO: alt calls parsers sequentially until one succeeds, which is not optimal.  Want to only call the correct parser, no sequencing.
     // Also run the risk of hitting the wrong parser since there is overlap in response codes.
     let result = alt((
-        parse_meta_status,
+        // parse_meta_status,
         |input| parse_meta_get_data_value(input),
         |input| parse_meta_set_data_value(input),
     ))(buf);
@@ -104,6 +104,7 @@ fn parse_meta_get_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
         }
         // match arm for "HD" response when v flag is omitted
         Response::Status(Status::Exists) => {
+            println!("parse_meta_get_data_value: Status::Exists");
             // no value (data block) or size in this case, potentially just flags
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)?;
 

--- a/src/parser/meta.rs
+++ b/src/parser/meta.rs
@@ -598,7 +598,7 @@ mod tests {
         let input = b"HD\r\n";
         let (remaining, response) = parse_meta_get_data_value(input).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         assert_eq!(response, Response::Data(None));
     }
@@ -608,7 +608,7 @@ mod tests {
         let input = b"HD h1 c1 l123\r\n";
         let (remaining, response) = parse_meta_get_data_value(input).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         match response {
             Response::Data(Some(values)) => {
@@ -686,7 +686,7 @@ mod tests {
     fn test_parse_meta_get_data_value_cache_miss() {
         let input = b"EN\r\n";
         let (remaining, response) = parse_meta_get_data_value(input).unwrap();
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
         assert_eq!(response, Response::Status(Status::NotFound));
     }
 
@@ -695,7 +695,7 @@ mod tests {
         let input = b"EN Oopaque-token\r\n";
         let (remaining, response) = parse_meta_get_data_value(input).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         match response {
             Response::Data(Some(values)) => {
@@ -717,7 +717,7 @@ mod tests {
     fn test_parse_meta_get_data_value_cache_miss_with_k_flag() {
         let input = b"EN ktest-key\r\n";
         let (remaining, response) = parse_meta_get_data_value(input).unwrap();
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         match response {
             Response::Data(Some(values)) => {
@@ -844,7 +844,7 @@ mod tests {
         let server_response = b"HD\r\n";
         let (remaining, response) = parse_meta_set_data_value(server_response).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         assert_eq!(response, Response::Status(Status::Stored));
     }
@@ -854,7 +854,7 @@ mod tests {
         let server_response = b"NS\r\n";
         let (remaining, response) = parse_meta_set_data_value(server_response).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         assert_eq!(response, Response::Status(Status::NotStored));
     }
@@ -864,7 +864,7 @@ mod tests {
         let server_response = b"EX\r\n";
         let (remaining, response) = parse_meta_set_data_value(server_response).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         assert_eq!(response, Response::Status(Status::Exists));
     }
@@ -874,7 +874,7 @@ mod tests {
         let server_response = b"NF\r\n";
         let (remaining, response) = parse_meta_set_data_value(server_response).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         assert_eq!(response, Response::Status(Status::NotFound));
     }
@@ -884,7 +884,7 @@ mod tests {
         let server_response = b"HD O123\r\n";
         let (remaining, response) = parse_meta_set_data_value(server_response).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         match response {
             Response::Data(Some(values)) => {
@@ -906,7 +906,7 @@ mod tests {
         let server_response = b"HD ktest-key\r\n";
         let (remaining, response) = parse_meta_set_data_value(server_response).unwrap();
 
-        assert_eq!(remaining, b"\r\n");
+        assert_eq!(remaining, b"");
 
         match response {
             Response::Data(Some(values)) => {

--- a/src/parser/meta.rs
+++ b/src/parser/meta.rs
@@ -52,7 +52,7 @@ pub fn parse_meta_get_response(buf: &[u8]) -> Result<Option<(usize, Response)>, 
 pub fn parse_meta_set_response(buf: &[u8]) -> Result<Option<(usize, Response)>, ErrorKind> {
     let bufn = buf.len();
 
-    let result = parse_meta_get_data_value(buf);
+    let result = parse_meta_set_data_value(buf);
 
     match result {
         Ok((left, response)) => {

--- a/src/parser/meta.rs
+++ b/src/parser/meta.rs
@@ -1,22 +1,17 @@
 use nom::{
     branch::alt,
     bytes::streaming::{tag, take, take_while1},
-    character::{
-        complete::digit1,
-        streaming::{crlf, space0, space1},
-    },
-    combinator::{map, map_res, value},
-    error::ErrorKind::Fail,
+    character::streaming::{crlf, space1},
+    combinator::{map, value},
     multi::many0,
-    sequence::{pair, preceded, terminated, tuple},
+    sequence::{terminated, tuple},
     IResult,
 };
 
 use super::{parse_u32, ErrorKind, MetaValue, Response, Status, Value};
 use crate::Error;
 
-// TODO: remove this later in favour of individual parse_meta_*_status methods
-#[allow(dead_code)]
+// TODO: remove this later in favour of individual parse_meta_*_status methods]
 pub fn parse_meta_status(buf: &[u8]) -> IResult<&[u8], Response> {
     terminated(
         alt((
@@ -48,7 +43,6 @@ pub fn parse_meta_get_status(buf: &[u8]) -> IResult<&[u8], Response> {
 }
 
 // TODO: refactor this into individual parse_meta_*_response methods
-#[allow(dead_code)]
 pub fn parse_meta_response(buf: &[u8]) -> Result<Option<(usize, Response)>, ErrorKind> {
     let bufn = buf.len();
     // TODO: alt calls parsers sequentially until one succeeds, which is not optimal.  Want to only call the correct parser, no sequencing.

--- a/src/parser/meta.rs
+++ b/src/parser/meta.rs
@@ -104,7 +104,6 @@ fn parse_meta_get_data_value(buf: &[u8]) -> IResult<&[u8], Response> {
         }
         // match arm for "HD" response when v flag is omitted
         Response::Status(Status::Exists) => {
-            println!("parse_meta_get_data_value: Status::Exists");
             // no value (data block) or size in this case, potentially just flags
             let (input, meta_values_array) = parse_meta_flag_values_as_slice(input)?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -24,9 +24,9 @@ pub struct Value {
     /// CAS identifier.
     pub cas: Option<u64>,
     /// Flags for this key.
+    /// Defaults to 0.
     /// NOTE: This is the client bitflags, not meta flags
     /// which is an opaque number passed by the client
-    /// Defaults to 0.
     pub flags: Option<u32>,
     /// Data for this key.
     pub data: Option<Vec<u8>>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -72,6 +72,8 @@ pub enum Status {
     Deleted,
     /// The key was touched.
     Touched,
+    /// Quiet mode no-op.
+    NoOp,
     /// The key already exists.
     Exists,
     /// The key already exists and value was requested in the meta protocol.
@@ -158,6 +160,7 @@ impl fmt::Display for Status {
             Self::NotStored => write!(f, "not stored"),
             Self::Deleted => write!(f, "deleted"),
             Self::Touched => write!(f, "touched"),
+            Self::NoOp => write!(f, "no-op"),
             Self::Exists => write!(f, "exists"),
             Self::Value => write!(f, "value"),
             Self::NotFound => write!(f, "not found"),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,7 +14,7 @@ pub use ascii::{parse_ascii_metadump_response, parse_ascii_response, parse_ascii
 
 mod meta;
 #[allow(unused_imports)]
-pub use meta::parse_meta_response;
+pub use meta::parse_meta_get_response;
 
 /// A value from memcached.
 #[derive(Clone, Debug, PartialEq)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,11 +2,11 @@ use async_memcached::{Client, Error, ErrorKind, Status};
 use rand::seq::IteratorRandom;
 use serial_test::{parallel, serial};
 
-// Note: Each test should run with keys unique to that test to avoid async conflicts.  Because these tests run concurrently,
+// NOTE: Each test should run with keys unique to that test to avoid async conflicts.  Because these tests run concurrently,
 // it's possible to delete/overwrite keys created by another test before they're read.
 
-const LARGE_PAYLOAD_SIZE: usize = 1000 * 1024;
-const MAX_KEY_LENGTH: usize = 250;
+const LARGE_PAYLOAD_SIZE: usize = 1024 * 1024; // 1 MB, default memcached max value size
+const MAX_KEY_LENGTH: usize = 250; // 250 bytes, default memcached max key length
 
 async fn setup_client(keys: &[&str]) -> Client {
     let mut client = Client::new("tcp://127.0.0.1:11211")
@@ -82,6 +82,171 @@ async fn test_get_fails_with_key_too_long() {
         get_result,
         Err(Error::Protocol(Status::Error(ErrorKind::KeyTooLong)))
     ));
+}
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+#[parallel]
+async fn test_meta_get_cache_hit_with_no_flags() {
+    let key = "meta-get-test-key-cache-hit-with-no-flags";
+    let value = "test-value";
+
+    let mut client = setup_client(&[key]).await;
+
+    let set_result = client.set(key, value, None, None).await.unwrap();
+    assert_eq!(set_result, ());
+
+    let get_result = client.get(key).await.unwrap();
+    println!("get_result: {:?}", std::str::from_utf8(&get_result.unwrap().data.unwrap()).unwrap());
+
+    let flags = None;
+    let result = client.meta_get(key, flags).await.unwrap();
+
+    assert!(result.is_none());
+}
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+#[parallel]
+async fn test_meta_get_with_only_v_flag() {
+    let key = "meta-get-test-key-with-only-v-flag";
+    let value = "test-value";
+
+    let mut client = setup_client(&[key]).await;
+
+    client.set(key, value, None, None).await.unwrap();
+
+    let flags = ["v"];
+    let result = client.meta_get(key, Some(&flags)).await.unwrap();
+
+    assert!(result.is_some());
+    let result_meta_value = result.unwrap();
+
+    assert_eq!(
+        String::from_utf8(result_meta_value.data.unwrap()).unwrap(),
+        value
+    );
+}
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+#[parallel]
+async fn test_meta_get_with_many_flags() {
+    let key = "meta-get-test-key-with-many-flags";
+    let value = "test-value";
+    let ttl = 3600; // 1 hour
+
+    let mut client = setup_client(&[key]).await;
+
+    // Set the key with a TTL
+    client.set(key, value, Some(ttl), None).await.unwrap();
+
+    // Perform a get to ensure the item has been hit
+    let result = client.get(key).await.unwrap();
+    let result_value = result.unwrap();
+    assert_eq!(
+        String::from_utf8(result_value.data.unwrap()).unwrap(),
+        value
+    );
+
+    let flags = ["v", "h", "l", "t", "O9001"];
+    let result = client.meta_get(key, Some(&flags)).await.unwrap();
+
+    assert!(result.is_some());
+    let result_meta_value = result.unwrap();
+
+    assert_eq!(
+        String::from_utf8(result_meta_value.data.unwrap()).unwrap(),
+        value
+    );
+
+    let meta_flag_values = result_meta_value.meta_values.unwrap();
+    assert!(meta_flag_values.hit_before.unwrap());
+    assert_eq!(meta_flag_values.last_accessed.unwrap(), 0);
+    assert!(meta_flag_values.ttl_remaining.unwrap() > 0);
+    assert_eq!(meta_flag_values.opaque_token.unwrap(), "9001".as_bytes());
+}
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+#[parallel]
+async fn test_meta_get_with_many_flags_and_no_value() {
+    let key = "meta-get-test-key-with-many-flags";
+    let value = "test-value";
+    let ttl = 3600; // 1 hour
+
+    let mut client = setup_client(&[key]).await;
+
+    // Set the key with a TTL
+    client.set(key, value, Some(ttl), None).await.unwrap();
+
+    // Perform a get to ensure the item has been hit (for the h flag), and confirm the value exists
+    let get_result = client.get(key).await.unwrap();
+    let get_result_value = get_result.unwrap();
+    assert_eq!(
+        String::from_utf8(get_result_value.data.unwrap()).unwrap(),
+        value
+    );
+
+    let flags = ["h", "l", "t", "O9001"];
+    let meta_get_result = client.meta_get(key, Some(&flags)).await.unwrap();
+
+    assert!(meta_get_result.is_some());
+    let meta_get_result_value = meta_get_result.unwrap();
+
+    assert_eq!(
+        meta_get_result_value.data, None
+    );
+
+    let meta_flag_values = meta_get_result_value.meta_values.unwrap();
+    assert!(meta_flag_values.hit_before.unwrap());
+    assert_eq!(meta_flag_values.last_accessed.unwrap(), 0);
+    assert!(meta_flag_values.ttl_remaining.unwrap() > 0);
+    assert_eq!(meta_flag_values.opaque_token.unwrap(), "9001".as_bytes());
+}
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+#[parallel]
+async fn test_meta_get_not_found() {
+    let key = "meta-get-test-key-not-found";
+    let flags = ["v", "h", "l", "t"];
+    let mut client = setup_client(&[key]).await;
+
+    let result = client.meta_get(key, Some(&flags)).await.unwrap();
+    assert_eq!(result, None);
+}
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+#[parallel]
+async fn test_meta_get_not_found_with_opaque_flag() {
+    let key = "meta-get-test-key-not-found";
+    let flags = ["v", "O9001"];
+    let mut client = setup_client(&[key]).await;
+
+    let result = client.meta_get(key, Some(&flags)).await.unwrap();
+
+    assert_eq!(
+        result.unwrap().meta_values.unwrap().opaque_token,
+        Some("9001".as_bytes().to_vec())
+    );
+}
+
+#[ignore = "Relies on a running memcached server"]
+#[tokio::test]
+#[parallel]
+async fn test_meta_get_not_found_with_k_flag() {
+    let key = "meta-get-test-key-not-found";
+    let flags = ["v", "O9001"];
+    let mut client = setup_client(&[key]).await;
+
+    let result = client.meta_get(key, Some(&flags)).await.unwrap();
+
+    assert_eq!(
+        result.unwrap().key,
+        key.as_bytes().to_vec()
+    );
 }
 
 #[ignore = "Relies on a running memcached server"]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -294,8 +294,6 @@ async fn test_quiet_mode_meta_get_key_too_long() {
 
     let result = client.meta_get(&key, Some(&flags)).await;
 
-    println!("{:?}", result);
-
     assert!(matches!(
         result,
         Err(Error::Protocol(Status::Error(ErrorKind::KeyTooLong)))
@@ -313,8 +311,6 @@ async fn test_quiet_mode_meta_get_with_k_flag_and_cache_miss() {
     let flags = ["v", "k", "q"];
 
     let result = client.meta_get(key, Some(&flags)).await;
-
-    println!("{:?}", result);
 
     assert!(result.is_ok());
     assert!(result.unwrap().is_none());

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -97,7 +97,10 @@ async fn test_meta_get_cache_hit_with_no_flags() {
     assert_eq!(set_result, ());
 
     let get_result = client.get(key).await.unwrap();
-    println!("get_result: {:?}", std::str::from_utf8(&get_result.unwrap().data.unwrap()).unwrap());
+    println!(
+        "get_result: {:?}",
+        std::str::from_utf8(&get_result.unwrap().data.unwrap()).unwrap()
+    );
 
     let flags = None;
     let result = client.meta_get(key, flags).await.unwrap();
@@ -171,7 +174,7 @@ async fn test_meta_get_with_many_flags() {
 #[tokio::test]
 #[parallel]
 async fn test_meta_get_with_many_flags_and_no_value() {
-    let key = "meta-get-test-key-with-many-flags";
+    let key = "meta-get-test-key-with-many-flags-no-value";
     let value = "test-value";
     let ttl = 3600; // 1 hour
 
@@ -194,9 +197,7 @@ async fn test_meta_get_with_many_flags_and_no_value() {
     assert!(meta_get_result.is_some());
     let meta_get_result_value = meta_get_result.unwrap();
 
-    assert_eq!(
-        meta_get_result_value.data, None
-    );
+    assert_eq!(meta_get_result_value.data, None);
 
     let meta_flag_values = meta_get_result_value.meta_values.unwrap();
     assert!(meta_flag_values.hit_before.unwrap());
@@ -243,10 +244,7 @@ async fn test_meta_get_not_found_with_k_flag() {
 
     let result = client.meta_get(key, Some(&flags)).await.unwrap();
 
-    assert_eq!(
-        result.unwrap().key,
-        key.as_bytes().to_vec()
-    );
+    assert_eq!(result.unwrap().key, key.as_bytes().to_vec());
 }
 
 #[ignore = "Relies on a running memcached server"]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -93,8 +93,7 @@ async fn test_meta_get_cache_hit_with_no_flags() {
 
     let mut client = setup_client(&[key]).await;
 
-    let set_result = client.set(key, value, None, None).await.unwrap();
-    assert_eq!(set_result, ());
+    client.set(key, value, None, None).await.unwrap();
 
     let get_result = client.get(key).await.unwrap();
     println!(
@@ -566,7 +565,7 @@ async fn test_set_fails_with_value_too_large() {
 #[tokio::test]
 #[parallel]
 async fn test_get_multi() {
-    let keys = vec!["mg-key1", "mg-key2", "mg-key3"];
+    let keys = ["mg-key1", "mg-key2", "mg-key3"];
     let values = ["value1", "value2", "value3"];
 
     let mut client = setup_client(&keys).await;


### PR DESCRIPTION
<!-- Ensure you have run `cargo fmt` and `cargo clippy --all-features -- -D warnings` to catch linting errors. -->
<!-- Update CHANGELOG.md with with any changes included in this PR. -->
### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->
This PR introduces the implementation of the `meta_get` method, which uses the meta parser added in [a previous PR](https://github.com/Shopify/async-memcached/pull/66).  There are also small fixes to parsing behaviour that became necessary as edge cases were revealed with actual use of the parser.

### Details - How are you making this change?  What are the effects of this change?
<!-- If this is a PR for a new feature, changed feature or a bug fix: -->
<!-- Link to an issue or provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- If you are proposing changes to existing code, please run `cargo bench` against main branch and your feature branch. -->
<!-- Include results of your benchmarks in a code block in this section to show performance changes. -->
We are building the meta protocol in `async-memcached` with the full scope of flags available in mind.  As such, we are keeping methods broad, and extracting desired functionality from the general methods will be done through the flags provided and is left up to the user.  There is no prescribing of flags in this implementation.

Meta Get covers the [range of operations](https://github.com/memcached/memcached/blob/5609673ed29db98a377749fab469fe80777de8fd/doc/protocol.txt#L494) that correspond to `get`, `gets`, `gat`, `gats` and `touch` which all use different flag combinations.  `meta_get` takes optional flags because it is possible to bump the LRU for an item through what is essentially a no-op.  The `v` flag for value return does not need to be provided for all uses of `mg`, such as when using `touch` behaviour to update the TTL of a cached item.

================

Benchmarks for `meta_get` vs `meta_get_concat` with small key and value ("foo" & "bar"):

```
     Running benches/bench.rs (target/release/deps/bench-62483f1fc831355c)
Gnuplot not found, using plotters backend
get_small               time:   [33.272 µs 33.687 µs 34.316 µs]
                        change: [-8.7210% -7.6317% -6.4967%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

bench meta_get          time:   [28.778 µs 28.873 µs 28.977 µs]
                        change: [-1.3716% -0.8567% -0.3263%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe

bench meta_get_concat   time:   [29.076 µs 29.172 µs 29.284 µs]
                        change: [-1.0130% -0.5647% -0.1286%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
```

Benchmarks for ASCII get vs Meta Get methods with max key size and max value size (250 bytes & 1MB):

```
     Running benches/bench.rs (target/release/deps/bench-62483f1fc831355c)
Gnuplot not found, using plotters backend
bench ascii get         time:   [245.16 µs 246.59 µs 248.90 µs]
                        change: [-0.5506% +1.6244% +4.9168%] (p = 0.29 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe

bench meta_get          time:   [117.66 µs 117.89 µs 118.08 µs]
                        change: [+1.2427% +1.7885% +2.3200%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  6 (6.00%) high severe

bench meta_get_concat   time:   [117.76 µs 118.04 µs 118.33 µs]
                        change: [+1.0628% +1.7042% +2.3663%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  4 (4.00%) high severe
```

TL;DR - `meta_get` and `meta_get_concat` are both faster than ASCII get under similar circumstances (ASCII get is ~16.2% slower in the small key/value test and ~2x slower in the worst case with max length key and value).  No statistical difference between the two `meta_get` methods in this style of benchmark at this scale, similar to what we have seen with the ASCII get methods.
<!-- -------------------------------------------- -->

<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

<!-- PR(s) covered by this crate version bump: -->

<!-- output of `cargo release <LEVEL> -v` dryrun: -->
