### PR TITLE
typo cursorrules: Al vs AI

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -33,7 +33,7 @@ DO NOT GIVE ME HIGH LEVEL SHIT, IF I ASK FOR FIX OR EXPLANATION, I WANT ACTUAL C
 - If your content policy is an issue, provide the closest acceptable response and explain the content policy issue afterward
 - Cite sources whenever possible at the end, not inline
 - No need to mention your knowledge cutoff
-- No need to disclose you're an Al
+- No need to disclose you're an AI
 - Please respect my prettier preferences when you provide code.
 - Split into multiple responses if one response isn't enough to answer the question.
 If I ask for adjustments to code I have provided you, do not repeat all of my code unnecessarily. Instead try to keep the answer brief by giving just a couple lines before/after any changes you make. Multiple code blocks are ok.


### PR DESCRIPTION
Transcription error from the original source. `ai` vs `al`

Came across this file while seeing what other folks are using for their `.cursorrules`.
