### PR TITLE
Add panic guard to drive_receive function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `meta_set` method to the meta protocol.
 - Added `meta_delete` method to the meta protocol.
 - Added `meta_increment` and `meta_decrement` methods to the meta protocol to cover Meta Arithmetic functionality.
+- Added panic guard on `drive_receive` to prevent panics on `split_to` calls where the buffer is empty.
 
 ### Changed
 - Refactored some wall-clock benchmarks to yield more realistic results for expensive set operations.

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -86,7 +86,7 @@ async fn main() {
     client
         .set(increment_key, "0", None, None)
         .await
-        .expect(format!("failed to set {}", increment_key).as_str());
+        .unwrap_or_else(|_| panic!("failed to set {}", increment_key));
 
     match client.increment(increment_key, amount).await {
         Ok(value) => println!(
@@ -115,7 +115,7 @@ async fn main() {
     client
         .set(decrement_key, "10", None, None)
         .await
-        .expect(format!("failed to set {}", decrement_key).as_str());
+        .unwrap_or_else(|_| panic!("failed to set {}", decrement_key));
 
     match client.decrement(decrement_key, amount).await {
         Ok(value) => println!(

--- a/examples/unix.rs
+++ b/examples/unix.rs
@@ -86,7 +86,7 @@ async fn main() {
     client
         .set(increment_key, "0", None, None)
         .await
-        .expect(format!("failed to set {}", increment_key).as_str());
+        .unwrap_or_else(|_| panic!("failed to set {}", increment_key));
 
     match client.increment(increment_key, amount).await {
         Ok(value) => println!(
@@ -115,7 +115,7 @@ async fn main() {
     client
         .set(decrement_key, "10", None, None)
         .await
-        .expect(format!("failed to set {}", decrement_key).as_str());
+        .unwrap_or_else(|_| panic!("failed to set {}", decrement_key));
 
     match client.decrement(decrement_key, amount).await {
         Ok(value) => println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,8 @@ impl Client {
             if n > self.buf.len() {
                 return Err(Status::Error(ErrorKind::Client(
                     "Buffer length is less than last read length".to_string(),
-                )).into());
+                ))
+                .into());
             }
             let _ = self.buf.split_to(n);
         }
@@ -299,7 +300,7 @@ pub struct MetadumpIter<'a> {
     done: bool,
 }
 
-impl<'a> MetadumpIter<'a> {
+impl MetadumpIter<'_> {
     /// Gets the next result for the current operation.
     ///
     /// If there is another key in the dump, `Some(Ok(KeyMetadata))` will be returned.  If there was

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,15 @@ impl Client {
     {
         // If we serviced a previous request, advance our buffer forward.
         if let Some(n) = self.last_read_n {
+            // Not sure how this situation occurs, but it seems to be related to transient network
+            // issues. This guard is here to prevent panics, but it's not clear what the correct
+            // behavior is. For now, we just return an error, which allows the caller to retry or
+            // fall back to the uncached data source as they see fit.
+            if n > self.buf.len() {
+                return Err(Status::Error(ErrorKind::Client(
+                    "Buffer length is less than last read length".to_string(),
+                )).into());
+            }
             let _ = self.buf.split_to(n);
         }
 

--- a/tests/resiliency_tests.rs
+++ b/tests/resiliency_tests.rs
@@ -286,7 +286,7 @@ mod tests {
 
         // Simulate a network error happening when the server responds back to the client.  A complete response is received for the first key but then
         // the connection is closed before the other responses are received.  Regardless, the server should still cache all the data.
-        let byte_limit = "STORED\r\n".as_bytes().len() + 1;
+        let byte_limit = "STORED\r\n".len() + 1;
 
         let _ = toxic_proxy
             .with_limit_data("downstream".into(), byte_limit as u32, 1.0)


### PR DESCRIPTION
<!-- Ensure you have run `cargo fmt` and `cargo clippy --tests --all-features` to catch linting errors. -->
<!-- Update CHANGELOG.md with with any changes included in this PR. -->
### TL;DR - What are you trying to accomplish?
<!-- One or two line summary of your change-->

We saw some transient panics related to the use of `split_to` in the `drive_receive` function. This PR adds a guard to return an error instead of panicking in the situation that we experienced, but _does not fix the underlying issue_. The aim is to at least allow for the caller of the library to recover from this situation.

### Details - How are you making this change?  What are the effects of this change?

`split_to` will panic when the passed in value is larger than the buffer length. This is what we saw when using the client to do basic `get` requests for just a handful of cases where there seem to be transient network issues that result in an empty buffer, despite having `last_read_n > 0`.

```
panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bytes-1.10.1/src/bytes_mut.rs:396:9: split_to out of bounds: 255 <= 0
```

I wasn't able to replicate this issue to verify it was related to network issues, but a guard against panicking here will at least allow the system to recover and move on from the error state.