### PR TITLE
Release version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-## [0.5.0] - 2025-03-31
-
 ### Added
 - Added `Toxiproxy` resiliency testing.
 - Added crate-level validation for key lengths.  Allowing a key that is too long through to the memcached protocol can lead to multiple errors being returned for a single operation, which leaves unexpected and unread bytes on the buffer.  Future operations can be parsed incorrectly if this is left unchecked, but validating key length is a simple check to prevent this behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.5.0] - 2025-03-31
+
 ### Added
 - Added `Toxiproxy` resiliency testing.
 - Added crate-level validation for key lengths.  Allowing a key that is too long through to the memcached protocol can lead to multiple errors being returned for a single operation, which leaves unexpected and unread bytes on the buffer.  Future operations can be parsed incorrectly if this is left unchecked, but validating key length is a simple check to prevent this behaviour.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-memcached"
-version = "0.5.0"
+version = "0.4.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
 readme = "README.md"
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/async-memcached"
 repository = "https://github.com/Shopify/async-memcached"
 
 [dependencies]
-bytes = "1.4"
+bytes = "1.10"
 nom = "7.1"
 dsn = "1.0"
 btoi = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-memcached"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
<!-- If this is a PR for a new crate version release: -->
<!-- Ensure the CHANGELOG.md is up to date and that it covers all changes being introduced in the new version -->
<!-- Version to bump to: -->

Releasing version `0.5.0` of async-memcached.

<!-- PR(s) covered by this crate version bump: -->

Releases PRs:

https://github.com/Shopify/async-memcached/pull/46
https://github.com/Shopify/async-memcached/pull/49
https://github.com/Shopify/async-memcached/pull/59
https://github.com/Shopify/async-memcached/pull/63
https://github.com/Shopify/async-memcached/pull/66
https://github.com/Shopify/async-memcached/pull/67
https://github.com/Shopify/async-memcached/pull/68
https://github.com/Shopify/async-memcached/pull/69
https://github.com/Shopify/async-memcached/pull/70
https://github.com/Shopify/async-memcached/pull/71
https://github.com/Shopify/async-memcached/pull/74
https://github.com/Shopify/async-memcached/pull/75

<!-- output of `cargo release <LEVEL> -v` dryrun: -->

```
[2025-03-31T14:47:38Z DEBUG reqwest::connect] starting new connection: https://index.crates.io/
[2025-03-31T14:47:38Z DEBUG cargo_release::steps] Files changed in async-memcached since v0.4.0: [
        "/Users/mtanous/src/github.com/Shopify/async-memcached/.cursorignore",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/.cursorrules",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/.github/pull_request_template.md",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/.github/workflows/ci.yml",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/.gitignore",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/CHANGELOG.md",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/Cargo.toml",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/README.md",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/benches/bench.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/benches/request_distribution_bench.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/examples/tcp.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/examples/unix.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/src/error.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/src/lib.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/src/parser/ascii_parser.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/src/parser/meta_parser.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/src/parser/mod.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/src/proto/ascii_protocol.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/src/proto/meta_protocol.rs",
        "/Users/mtanous/src/github.com/Shopify/async-memcached/src/proto/mod.rs",
    ]
[2025-03-31T14:47:38Z DEBUG globset] glob converted to regex: Glob { glob: "**/*", re: "(?-u)^(?:/?|.*/)[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, ZeroOrMore]) }
[2025-03-31T14:47:38Z DEBUG globset] built glob set; 0 literals, 1 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 1 regexes
   Upgrading async-memcached from 0.4.0 to 0.5.0
[2025-03-31T14:47:39Z DEBUG cargo_release::ops::cargo] change:
    --- /Users/mtanous/src/github.com/Shopify/async-memcached/Cargo.toml	original
    +++ /Users/mtanous/src/github.com/Shopify/async-memcached/Cargo.toml	updated
    @@ -1,6 +1,6 @@
     [package]
     name = "async-memcached"
    -version = "0.4.0"
    +version = "0.5.0"
     authors = ["Toby Lawrence <toby@nuclearfurnace.com>"]
     edition = "2018"
     readme = "README.md"

[2025-03-31T14:47:39Z DEBUG cargo_release::steps::release] updating lock file
[2025-03-31T14:47:39Z DEBUG cargo_release::ops::replace] processing replacements for file /Users/mtanous/src/github.com/Shopify/async-memcached/CHANGELOG.md
   Replacing in CHANGELOG.md
--- CHANGELOG.md	original
+++ CHANGELOG.md	replaced
@@ -10,6 +10,8 @@

 ## [Unreleased] - ReleaseDate

+## [0.5.0] - 2025-03-31
+
 ### Added
 - Added `Toxiproxy` resiliency testing.
 - Added crate-level validation for key lengths.  Allowing a key that is too long through to the memcached protocol can lead to multiple errors being returned for a single operation, which leaves unexpected and unread bytes on the buffer.  Future operations can be parsed incorrectly if this is left unchecked, but validating key length is a simple check to prevent this behaviour.
```
